### PR TITLE
Fix Python 3 imports

### DIFF
--- a/webauthn/__init__.py
+++ b/webauthn/__init__.py
@@ -1,9 +1,9 @@
 # flake8: noqa
-from webauthn import WebAuthnAssertionOptions
-from webauthn import WebAuthnAssertionResponse
-from webauthn import WebAuthnCredential
-from webauthn import WebAuthnMakeCredentialOptions
-from webauthn import WebAuthnRegistrationResponse
-from webauthn import WebAuthnUser
+from .webauthn import WebAuthnAssertionOptions
+from .webauthn import WebAuthnAssertionResponse
+from .webauthn import WebAuthnCredential
+from .webauthn import WebAuthnMakeCredentialOptions
+from .webauthn import WebAuthnRegistrationResponse
+from .webauthn import WebAuthnUser
 
 __version__ = '0.1'


### PR DESCRIPTION
Python 3 needs you to specify explicitly the relative import directory. Works after this.