### PR TITLE
Switch demo to using HTTPS as it is required for Chrome usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ There is a [Flask][4] demo available in the `flask_demo` directory. Follow these
 1. `cd flask_demo`
 2. `pip install -r requirements.txt`
 3. `python app.py`
-4. Go to [http://localhost:5000][5] in your web browser. Try registering and logging in with a compatible U2F or WebAuthn authenticator.
+4. Go to [https://localhost:5000][5] in your web browser. Try registering and logging in with a compatible U2F or WebAuthn authenticator.
 5. Profit?
 
 # Flask Demo (Docker)
@@ -107,7 +107,7 @@ To run the [Flask][4] demo with [Docker][6]:
 
 1. Install Docker.
 2. `docker-compose up -d`
-3. Go to [http://localhost:5000][5] in your web browser. Try registering and logging in with a compatible U2F or WebAuthn authenticator.
+3. Go to [https://localhost:5000][5] in your web browser. Try registering and logging in with a compatible U2F or WebAuthn authenticator.
 
 # Note
 
@@ -121,7 +121,7 @@ Currently, PyWebAuthn does not support performing the following optional verific
 [2]: https://www.mozilla.org/en-US/firefox/channel/desktop/
 [3]: https://www.google.com/chrome/browser/canary.html
 [4]: http://flask.pocoo.org/
-[5]: http://localhost:5000
+[5]: https://localhost:5000
 [6]: https://www.docker.com/
 [7]: https://www.w3.org/TR/webauthn/#dom-collectedclientdata-tokenbindingid
 [8]: https://www.w3.org/TR/webauthn/#dom-collectedclientdata-clientextensions

--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -32,8 +32,8 @@ db.init_app(app)
 login_manager = LoginManager()
 login_manager.init_app(app)
 
-ORIGIN = 'http://localhost:5000'
 RP_ID = 'localhost'
+ORIGIN = 'https://localhost:5000'
 
 # Trust anchors (trusted attestation roots) should be
 # placed in TRUST_ANCHOR_DIR.
@@ -241,4 +241,4 @@ def logout():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True)
+    app.run(host='0.0.0.0', ssl_context='adhoc', debug=True)


### PR DESCRIPTION
Chrome will return `undefined` for `navigator.credentials` unless the site is using HTTPS, rendering the current demo unusable. Luckily Flask has built-in support for serving over HTTPS with a self-signed certificate.

This is a resubmission of #5, which was accidentally not on its own branch.