### PR TITLE
Fix hashing clientDataJson, hashAlgorithm is no longer in the spec

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -891,9 +891,7 @@ def _get_client_data_hash(client_data, decoded_client_data):
 
     hash_alg = client_data.get('hashAlgorithm')
 
-    if not hash_alg:
-        return ''
-    if hash_alg == 'SHA-256':
+    if not hash_alg or hash_alg == 'SHA-256':
         return hashlib.sha256(decoded_client_data).digest()
     elif hash_alg == 'SHA-512':
         return hashlib.sha512(decoded_client_data).digest()


### PR DESCRIPTION
This fixes invalid signature problems as mentioned in issue #4. It looks like the spec has changed and `clientDataJson` no longer specifies a hash algorithm, causing the existing code to always hash an empty string. I tried to keep the change as small and concise as possible, but someone with more knowledge may want to look at it if `_get_client_data_hash` should simply always use `SHA-256` now as the spec only mentions the client data JSON as being hashed with that algorithm.