### PR TITLE
Make RS256 one of the pubKeyCredParms for reg

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -101,7 +101,7 @@ class WebAuthnMakeCredentialOptions(object):
             },
             'pubKeyCredParams': [
                 {
-                    'alg': 'ES256',
+                    'alg': -257,
                     'type': 'public-key',
                 },
                 {


### PR DESCRIPTION
Currently the two `pubKeyCredParams` provided for registration options are 'ES256' and -7.

1. I don't believe string values for `alg`, such as 'ES256' are valid, so it's likely being ignored by browsers
2. -7 is the identifier for 'ES256' anyway, so it's duplicated

Most all examples (including the WebAuthn spec) provide -7 (ES256) and -257 (RS256) as `pubKeyCredParams`.