### PR TITLE
Only include user icon URL in reg if provided

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -96,8 +96,7 @@ class WebAuthnMakeCredentialOptions(object):
             'user': {
                 'id': self.user_id,
                 'name': self.username,
-                'displayName': self.display_name,
-                'icon': self.icon_url
+                'displayName': self.display_name
             },
             'pubKeyCredParams': [
                 {
@@ -119,6 +118,9 @@ class WebAuthnMakeCredentialOptions(object):
                 'webauthn.loc': True
             }
         }
+        
+        if self.icon_url:
+            registration_dict['user']['icon'] = self.icon_url
 
         return registration_dict
 


### PR DESCRIPTION
Newer versions of Chrome (68+) don't seem to like a user's `icon` being set to `null`. I'd been passing `None` to `WebAuthnMakeCredentialOptions` for the icon URL, and this used to work fine (with it showing up in the JSON as `null`) but now it causes a silent failure in Chrome, where Chrome's UI initiates the authenticator process, but never sends the message to the authenticator. I tracked this down to the `icon` being `null`. I'll open an issue with Chromium as the silent failure is definitely a bug.

In the mean-time, I don't think `null` is an allowed value for `icon` anyway in the spec, so only include it in the registration dict if it's provided.