### PR TITLE
Add Packed Attestation Format (Large Refactor)

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -96,8 +96,7 @@ class WebAuthnMakeCredentialOptions(object):
             'user': {
                 'id': self.user_id,
                 'name': self.username,
-                'displayName': self.display_name,
-                'icon': self.icon_url
+                'displayName': self.display_name
             },
             'pubKeyCredParams': [
                 {
@@ -119,6 +118,9 @@ class WebAuthnMakeCredentialOptions(object):
                 'webauthn.loc': True
             }
         }
+
+        if self.icon_url:
+            registration_dict['user']['icon'] = self.icon_url
 
         return registration_dict
 


### PR DESCRIPTION
This includes PR #15.

So, this started as what the title suggests, just adding the `packed` attestation format, as I found that my newer Yubico security key (which supports FIDO2) was now returning that format.

However, as I got into it there were a few thing I needed to refactor to make this fit. Mainly:
* Pull the verify signature logic into it's own function since this is reused in various spots. This has the added benefit that it supports three algorithms mentioned in the spec now: ES256, RS256, and PS256.
* Pull the logic for loading a COSE encoded key into a `cryptography` public key out into it's own function, as it was duplicated in several places (with slightly varying implementations) and drop `_decode_public_key`
* `_verify_attestation_statement` now returns the raw public key data (COSE format) from the `auth_data`. Before it was returning an encoded format specific to the U2F attestation.
* Breaking change: The public key value returned in `WebAuthnCredential` is now the base-64 encoded COSE key format. This was necessary to support algorithms other than ES256.

The last bit means any existing implementations which have stored public keys wouldn't work with this PR. A hack could be made to support them (try the new load, if that fails, try the old `_decode_public_key`). The old method stored the public key in a manner that only worked with ES256, so that had to get broken at some point to support all algorithms.

The packed attestation format is fully implemented minus the ECDAA attestation type. However, I've only tested the go right path for my security key, untested bits are RS256, PS256, and self-attestation.