### PR TITLE
Use constant time comparison for verification

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -7,11 +7,14 @@ import os
 import struct
 import sys
 
+from builtins import bytes
+
 import cbor2
 import six
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import constant_time
 from cryptography.hazmat.primitives.asymmetric.ec import ECDSA
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicNumbers
 from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
@@ -1056,7 +1059,9 @@ def _verify_challenge(received_challenge, sent_challenge):
         return False
     if not sent_challenge:
         return False
-    if sent_challenge != received_challenge:
+    if not constant_time.bytes_eq(
+            bytes(sent_challenge, encoding='utf-8'),
+            bytes(received_challenge, encoding='utf-8')):
         return False
 
     return True
@@ -1114,7 +1119,9 @@ def _verify_authenticator_extensions(client_data):
 def _verify_rp_id_hash(auth_data_rp_id_hash, rp_id):
     rp_id_hash = hashlib.sha256(rp_id).digest()
 
-    return auth_data_rp_id_hash == rp_id_hash
+    return constant_time.bytes_eq(
+        bytes(auth_data_rp_id_hash, encoding='utf-8'),
+        bytes(rp_id_hash, encoding='utf-8'))
 
 
 def _verify_attestation_statement_format(fmt):


### PR DESCRIPTION
Took this idea from the [Yubico FIDO 2](https://github.com/Yubico/python-fido2) Python library. Use constant time comparisons to prevent timing attacks.

It's probably smartest to put an expiration time on challenges to prevent giving attackers an infinite number of tries anyway, but since the library user in this case controls the challenge and it's storage/expiration that can't be guaranteed, so constant time comparison are a nice extra bit of hardening.