### PR TITLE
Add default value for all arguments in the WebAuthnUser class

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -175,8 +175,20 @@ class WebAuthnAssertionOptions(object):
 
 
 class WebAuthnUser(object):
-    def __init__(self, user_id, username, display_name, icon_url,
-                 credential_id, public_key, sign_count, rp_id):
+    def __init__(self, *args, **kwargs):
+        if len(args) == 8:
+            user_id, username, display_name, icon_url, \
+                credential_id, public_key, sign_count, rp_id = args
+        else:
+            user_id = kwargs.get("user_id", None)
+            username = kwargs.get("username", None)
+            display_name = kwargs.get("display_name", None)
+            icon_url = kwargs.get("icon_url", None)
+            credential_id = kwargs.get("credential_id", None)
+            public_key = kwargs.get("public_key", None)
+            sign_count = kwargs.get("sign_count", None)
+            rp_id = kwargs.get("rp_id", None)
+        
         self.user_id = user_id
         self.username = username
         self.display_name = display_name

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -186,8 +186,8 @@ class WebAuthnAssertionOptions(object):
 
 
 class WebAuthnUser(object):
-    def __init__(self, user_id=None, username=None, display_name=None, icon_url=None,
-                 credential_id=None, public_key=None, sign_count=None, rp_id=None):
+    def __init__(self, user_id, username, display_name, icon_url,
+                 credential_id, public_key, sign_count, rp_id):
         
         if not credential_id:
             raise WebAuthnUserDataMissing("credential_id missing")

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -1066,13 +1066,16 @@ class WebAuthnAssertionResponse(object):
             #             or not, is Relying Party-specific.
             sc = decoded_a_data[33:37]
             sign_count = struct.unpack('!I', sc)[0]
-            if sign_count:
-                if self.webauthn_user.sign_count == None:
-                    raise WebAuthnUserDataMissing("sign_count missing")
 
-                if sign_count <= self.webauthn_user.sign_count:
-                    raise AuthenticationRejectedException(
-                        'Duplicate authentication detected.')
+            if not sign_count:
+                raise AuthenticationRejectedException('Unable to parse sign_count.')
+
+            if not self.webauthn_user.sign_count:
+                raise WebAuthnUserDataMissing('sign_count missing from WebAuthnUser.')
+
+            if sign_count <= self.webauthn_user.sign_count:
+                raise AuthenticationRejectedException(
+                    'Duplicate authentication detected.')
 
             # Step 18.
             #

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -200,10 +200,10 @@ class WebAuthnUser(object):
             sign_count = kwargs.get("sign_count", None)
             rp_id = kwargs.get("rp_id", None)
         
-        if credential_id == None:
+        if not credential_id:
             raise WebAuthnUserDataMissing("credential_id missing")
 
-        if rp_id == None:
+        if not rp_id:
             raise WebAuthnUserDataMissing("rp_id missing")
 
         self.user_id = user_id
@@ -869,7 +869,7 @@ class WebAuthnAssertionResponse(object):
             # If credential.response.userHandle is present, verify that the user
             # identified by this value is the owner of the public key credential
             # identified by credential.id.
-            if self.webauthn_user.username == None:
+            if not self.webauthn_user.username:
                 raise WebAuthnUserDataMissing("username missing")
             
             user_handle = self.assertion_response.get('userHandle')
@@ -889,7 +889,7 @@ class WebAuthnAssertionResponse(object):
             if not isinstance(self.webauthn_user, WebAuthnUser):
                 raise AuthenticationRejectedException('Invalid user type.')
 
-            if self.webauthn_user.public_key == None:
+            if not self.webauthn_user.public_key:
                 raise WebAuthnUserDataMissing("public_key missing")
 
             credential_public_key = self.webauthn_user.public_key

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -847,6 +847,9 @@ class WebAuthnAssertionResponse(object):
             # If credential.response.userHandle is present, verify that the user
             # identified by this value is the owner of the public key credential
             # identified by credential.id.
+            if self.webauthn_user.username == None:
+                raise WebAuthnUserDataMissing("username missing")
+            
             user_handle = self.assertion_response.get('userHandle')
             if user_handle:
                 if not user_handle == self.webauthn_user.username:
@@ -863,6 +866,9 @@ class WebAuthnAssertionResponse(object):
 
             if not isinstance(self.webauthn_user, WebAuthnUser):
                 raise AuthenticationRejectedException('Invalid user type.')
+
+            if self.webauthn_user.public_key == None:
+                raise WebAuthnUserDataMissing("public_key missing")
 
             credential_public_key = self.webauthn_user.public_key
             public_key_alg, user_pubkey = _load_cose_public_key(
@@ -1037,7 +1043,10 @@ class WebAuthnAssertionResponse(object):
             #             or not, is Relying Party-specific.
             sc = decoded_a_data[33:37]
             sign_count = struct.unpack('!I', sc)[0]
-            if sign_count or self.webauthn_user.sign_count:
+            if sign_count:
+                if self.webauthn_user.sign_count == None:
+                    raise WebAuthnUserDataMissing("sign_count missing")
+
                 if sign_count <= self.webauthn_user.sign_count:
                     raise AuthenticationRejectedException(
                         'Duplicate authentication detected.')

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -186,19 +186,8 @@ class WebAuthnAssertionOptions(object):
 
 
 class WebAuthnUser(object):
-    def __init__(self, *args, **kwargs):
-        if len(args) == 8:
-            user_id, username, display_name, icon_url, \
-                credential_id, public_key, sign_count, rp_id = args
-        else:
-            user_id = kwargs.get("user_id", None)
-            username = kwargs.get("username", None)
-            display_name = kwargs.get("display_name", None)
-            icon_url = kwargs.get("icon_url", None)
-            credential_id = kwargs.get("credential_id", None)
-            public_key = kwargs.get("public_key", None)
-            sign_count = kwargs.get("sign_count", None)
-            rp_id = kwargs.get("rp_id", None)
+    def __init__(self, user_id=None, username=None, display_name=None, icon_url=None,
+                 credential_id=None, public_key=None, sign_count=None, rp_id=None):
         
         if not credential_id:
             raise WebAuthnUserDataMissing("credential_id missing")

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -77,6 +77,8 @@ class AuthenticationRejectedException(Exception):
 class RegistrationRejectedException(Exception):
     pass
 
+class WebAuthnUserDataMissing(Exception):
+    pass
 
 class WebAuthnMakeCredentialOptions(object):
     def __init__(self, challenge, rp_name, rp_id, user_id, username,
@@ -189,6 +191,12 @@ class WebAuthnUser(object):
             sign_count = kwargs.get("sign_count", None)
             rp_id = kwargs.get("rp_id", None)
         
+        if credential_id == None:
+            raise WebAuthnUserDataMissing("credential_id missing")
+
+        if rp_id == None:
+            raise WebAuthnUserDataMissing("rp_id missing")
+
         self.user_id = user_id
         self.username = username
         self.display_name = display_name


### PR DESCRIPTION
I was asking myself why all arguments in the WebAuthnUser class are mendatory, but not always used.
I had this code working on production:

```
webauthn_user = webauthn.WebAuthnUser( 
    None, None, None, None,
    key[ 'credential_id' ], None, None, config.RP_ID
)
webauthn_assertion_options = webauthn.WebAuthnAssertionOptions( webauthn_user, challenge )
```

This is not a definitive PR, but a snippet to discuss (of course backwards-compatible ; need some checks in the library)

What do you think ?

Edit:
Same comment with this code:

```
webauthn_user = webauthn.WebAuthnUser( 
    None, session[ 'username' ], None, None,
    user[ 'credential_id' ], user[ 'pub_key' ], user[ 'sign_count' ], config.RP_ID
)

webauthn_assertion_response = webauthn.WebAuthnAssertionResponse( 
    webauthn_user,
    assertion_response,
    challenge,
    config.ORIGIN,
    uv_required = False
)
```