### PR TITLE
Allow multiple credentials during assertion

### DIFF
--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -120,7 +120,7 @@ def webauthn_begin_assertion():
         user.credential_id, user.pub_key, user.sign_count, user.rp_id)
 
     webauthn_assertion_options = webauthn.WebAuthnAssertionOptions(
-        [webauthn_user], challenge)
+        webauthn_user, challenge)
 
     return jsonify(webauthn_assertion_options.assertion_dict)
 

--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -120,7 +120,7 @@ def webauthn_begin_assertion():
         user.credential_id, user.pub_key, user.sign_count, user.rp_id)
 
     webauthn_assertion_options = webauthn.WebAuthnAssertionOptions(
-        webauthn_user, challenge)
+        [webauthn_user], challenge)
 
     return jsonify(webauthn_assertion_options.assertion_dict)
 

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -139,7 +139,7 @@ class WebAuthnMakeCredentialOptions(object):
 
 class WebAuthnAssertionOptions(object):
     def __init__(self, webauthn_user, challenge, timeout=60000):
-        if isinstance(list, webauthn_user):
+        if isinstance(webauthn_user, list):
             self.webauthn_users = webauthn_user
         else:
             self.webauthn_users = [webauthn_user]

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -138,8 +138,11 @@ class WebAuthnMakeCredentialOptions(object):
 
 
 class WebAuthnAssertionOptions(object):
-    def __init__(self, webauthn_users, challenge, timeout=60000):
-        self.webauthn_users = webauthn_users
+    def __init__(self, webauthn_user, challenge, timeout=60000):
+        if isinstance(list, webauthn_user):
+            self.webauthn_users = webauthn_user
+        else:
+            self.webauthn_users = [webauthn_user]
         self.challenge = challenge
         self.timeout = timeout
 


### PR DESCRIPTION
Updates `WebAuthnAssertionOptions` to take a list of `WebAuthnUser`s, each of which becomes the basis for a [`PublicKeyCredentialDescriptor`](https://w3c.github.io/webauthn/#dictdef-publickeycredentialdescriptor). 

Some additional constraints are introduced:
* There must be at least one element in the `webauthn_users` list
* Every element in `webauthn_users` must be a `WebAuthnUser`
* Each `WebAuthnUser` must have a valid credential ID
* All `WebAuthnUser`s must have the same `rp_id`

This last constraint isn't explicitly in the specification, but follows from our inclusion of the optional `PublicKeyCredentialRequestOptions.rpId` field. Our other options are to drop that field entirely (in which case the origin's effective domain will be used), or to drop the check and allow the actual verification to fail later on.

Edit: This introduces a breaking change to the API. If that's undesirable, I could refactor it to test for a single item first and listify it before continuing on to the rest of the changes. Let me know if that's what you'd like!