### PR TITLE
WebAuthnMakeCredentialOptions: configurable attestation conveyance

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -81,8 +81,11 @@ class WebAuthnUserDataMissing(Exception):
     pass
 
 class WebAuthnMakeCredentialOptions(object):
+
+    _attestation_forms = {'none', 'indirect', 'direct'}
+
     def __init__(self, challenge, rp_name, rp_id, user_id, username,
-                 display_name, icon_url, timeout=60000):
+                 display_name, icon_url, timeout=60000, attestation='direct'):
         self.challenge = challenge
         self.rp_name = rp_name
         self.rp_id = rp_id
@@ -91,6 +94,12 @@ class WebAuthnMakeCredentialOptions(object):
         self.display_name = display_name
         self.icon_url = icon_url
         self.timeout = timeout
+
+        attestation = str(attestation).lower()
+        if attestation not in self._attestation_forms:
+            raise ValueError('attestation must be a string and one of ' +
+                    ', '.join(self._attestation_forms))
+        self.attestation = attestation
 
     @property
     def registration_dict(self):
@@ -121,8 +130,7 @@ class WebAuthnMakeCredentialOptions(object):
             'excludeCredentials': [],
             # Relying Parties may use AttestationConveyancePreference to specify their
             # preference regarding attestation conveyance during credential generation.
-            'attestation':
-            'direct',  # none, indirect, direct
+            'attestation': self.attestation,
             'extensions': {
                 # Include location information in attestation.
                 'webauthn.loc': True


### PR DESCRIPTION
I modified `WebAuthnMakeCredentialOptions` to allow the configuration of the attestation conveyance that up until now was hard coded to `direct`.

I need to be able to set it to other values to respect users privacy. 

The interface of the new constructor is backwards compatible and values give to the new attestation parameter are verified to only allow values that are allowed by the specification. If a value is give that is not allowed a `ValueError` is raised.