### PR TITLE
Add support for authenticatorSelection->userVerification field

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -85,9 +85,11 @@ class WebAuthnUserDataMissing(Exception):
 class WebAuthnMakeCredentialOptions(object):
 
     _attestation_forms = {'none', 'indirect', 'direct'}
+    _userVerification = {'required','preferred','discouraged'}
 
     def __init__(self, challenge, rp_name, rp_id, user_id, username,
-                 display_name, icon_url, timeout=60000, attestation='direct'):
+                 display_name, icon_url, timeout=60000, attestation='direct',
+                 userVerification=None):
         self.challenge = challenge
         self.rp_name = rp_name
         self.rp_id = rp_id
@@ -102,6 +104,11 @@ class WebAuthnMakeCredentialOptions(object):
             raise ValueError('Attestation must be a string and one of ' +
                              ', '.join(self._attestation_forms))
         self.attestation = attestation
+
+        if userVerification != None and userVerification not in self._userVerification:
+            raise ValueError('userVerification must be a string and one of ' +
+                             ', '.join(self._userVerification))
+        self.userVerification = userVerification
 
     @property
     def registration_dict(self):
@@ -138,6 +145,11 @@ class WebAuthnMakeCredentialOptions(object):
                 'webauthn.loc': True
             }
         }
+
+        if self.userVerification:
+            registration_dict['authenticatorSelection'] = {
+                'userVerification': self.userVerification
+            }
 
         if self.icon_url:
             registration_dict['user']['icon'] = self.icon_url

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -105,7 +105,7 @@ class WebAuthnMakeCredentialOptions(object):
                              ', '.join(self._attestation_forms))
         self.attestation = attestation
 
-        if user_verification != None:
+        if user_verification is not None:
             user_verification = str(user_verification).lower()
             if user_verification not in self._user_verification:
                 raise ValueError('user_verification must be a string and one of ' +
@@ -148,7 +148,7 @@ class WebAuthnMakeCredentialOptions(object):
             }
         }
 
-        if self.user_verification:
+        if self.user_verification is not None:
             registration_dict['authenticatorSelection'] = {
                 'userVerification': self.user_verification
             }

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -105,9 +105,11 @@ class WebAuthnMakeCredentialOptions(object):
                              ', '.join(self._attestation_forms))
         self.attestation = attestation
 
-        if userVerification != None and userVerification not in self._userVerification:
-            raise ValueError('userVerification must be a string and one of ' +
-                             ', '.join(self._userVerification))
+        if userVerification != None:
+            userVerification = str(userVerification).lower()
+            if userVerification not in self._userVerification:
+                raise ValueError('userVerification must be a string and one of ' +
+                                 ', '.join(self._userVerification))
         self.userVerification = userVerification
 
     @property

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -85,11 +85,11 @@ class WebAuthnUserDataMissing(Exception):
 class WebAuthnMakeCredentialOptions(object):
 
     _attestation_forms = {'none', 'indirect', 'direct'}
-    _userVerification = {'required','preferred','discouraged'}
+    _user_verification = {'required', 'preferred', 'discouraged'}
 
     def __init__(self, challenge, rp_name, rp_id, user_id, username,
                  display_name, icon_url, timeout=60000, attestation='direct',
-                 userVerification=None):
+                 user_verification=None):
         self.challenge = challenge
         self.rp_name = rp_name
         self.rp_id = rp_id
@@ -105,12 +105,12 @@ class WebAuthnMakeCredentialOptions(object):
                              ', '.join(self._attestation_forms))
         self.attestation = attestation
 
-        if userVerification != None:
-            userVerification = str(userVerification).lower()
-            if userVerification not in self._userVerification:
-                raise ValueError('userVerification must be a string and one of ' +
-                                 ', '.join(self._userVerification))
-        self.userVerification = userVerification
+        if user_verification != None:
+            user_verification = str(user_verification).lower()
+            if user_verification not in self._user_verification:
+                raise ValueError('user_verification must be a string and one of ' +
+                                 ', '.join(self._user_verification))
+        self.user_verification = user_verification
 
     @property
     def registration_dict(self):
@@ -148,9 +148,9 @@ class WebAuthnMakeCredentialOptions(object):
             }
         }
 
-        if self.userVerification:
+        if self.user_verification:
             registration_dict['authenticatorSelection'] = {
-                'userVerification': self.userVerification
+                'userVerification': self.user_verification
             }
 
         if self.icon_url:


### PR DESCRIPTION
With the Windows update 1903, the behaviour seems different... With old versions of Windows, I was able to use my keys without any PIN. Since the update, the protocol used seems to be FIDO2 instead of FIDO-U2F, breaking some of my codes. 
After investigation, the `WebAuthnMakeCredentialOptions.registration_dict` property did not contain the `authenticatorSelection->userVerification` field (https://www.w3.org/TR/webauthn/#userVerificationRequirement).

This option allow the server to enforce or not the creation of a PIN (actual Windows behaviour) on the client-side, "e.g., in the interest of minimizing disruption to the user interaction flow" as mentionned in the W3C webauthn Recommendation linked.

This commit should not be api breaking, and the default behaviour is the same as without the commit.