### PR TITLE
Fix isinstance(..., int) check on Python 2.7

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -12,7 +12,7 @@ import sys
 import binascii
 import codecs
 
-from builtins import bytes
+from builtins import bytes, int
 
 import cbor2
 import six


### PR DESCRIPTION
Currently the `isinstance` check for `sign_count` will fail on Python2.7 if it is a `long`. This change makes that check pass as expected in both Python 2 and 3.