### PR TITLE
Handle authenticators not supporting the signature counter (Fixes #55).

### DIFF
--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -1077,7 +1077,10 @@ class WebAuthnAssertionResponse(object):
             #             or not, is Relying Party-specific.
             sc = decoded_a_data[33:37]
             sign_count = struct.unpack('!I', sc)[0]
-
+            
+            if sign_count == 0 and self.webauthn_user.sign_count == 0:
+                return sign_count
+            
             if not sign_count:
                 raise AuthenticationRejectedException('Unable to parse sign_count.')
 


### PR DESCRIPTION
The WebAuthN spec seems to allow for authenticators which do not support the signature counter (see step 17 in [7.2 Verifying an Authentication Assertion](https://www.w3.org/TR/webauthn/#verifying-asssertion)), i.e. the signature counter should only be checked if it is non-zero.