### PR TITLE
Flask Demo: improve base64 handing

### DIFF
--- a/flask_demo/static/js/webauthn.js
+++ b/flask_demo/static/js/webauthn.js
@@ -100,7 +100,7 @@ const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) =
     let {challenge, allowCredentials} = credentialRequestOptionsFromServer;
 
     challenge = Uint8Array.from(
-        atob(challenge), c => c.charCodeAt(0));
+        atob(challenge.replace(/\_/g, "/").replace(/\-/g, "+")), c => c.charCodeAt(0));
 
     allowCredentials = allowCredentials.map(credentialDescriptor => {
         let {id} = credentialDescriptor;
@@ -141,10 +141,18 @@ const getCredentialCreateOptionsFromServer = async (formData) => {
 const transformCredentialCreateOptions = (credentialCreateOptionsFromServer) => {
     let {challenge, user} = credentialCreateOptionsFromServer;
     user.id = Uint8Array.from(
-        atob(credentialCreateOptionsFromServer.user.id), c => c.charCodeAt(0));
+        atob(credentialCreateOptionsFromServer.user.id
+            .replace(/\_/g, "/")
+            .replace(/\-/g, "+")
+            ), 
+        c => c.charCodeAt(0));
 
     challenge = Uint8Array.from(
-        atob(credentialCreateOptionsFromServer.challenge), c => c.charCodeAt(0));
+        atob(credentialCreateOptionsFromServer.challenge
+            .replace(/\_/g, "/")
+            .replace(/\-/g, "+")
+            ),
+        c => c.charCodeAt(0));
     
     const transformedCredentialCreateOptions = Object.assign(
             {}, credentialCreateOptionsFromServer,

--- a/flask_demo/static/js/webauthn.js
+++ b/flask_demo/static/js/webauthn.js
@@ -47,7 +47,7 @@ const didClickRegister = async (e) => {
     try {
         credentialCreateOptionsFromServer = await getCredentialCreateOptionsFromServer(formData);
     } catch (err) {
-        return console.error("Failed to generate credential request options:", credentialCreateOptionsFromServer)
+        return console.error("Failed to generate credential request options:", err);
     }
 
     // convert certain members of the PublicKeyCredentialCreateOptions into


### PR DESCRIPTION
Errata:
webauthn.js line 50: catch clause should log `err` to console, not `credentialCreateOptionsFromServer`
`credentialCreateOptionsFromServer` is undefined in the catch clause. 

Base 64 handling:
call `replace()` to translate websafe base64 encoding to standard base64 encoding. This commit enables webauthn.js to support websafe base64 challenge strings.