### PR TITLE
Flask Demo: improve base64 handing

### DIFF
--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -68,14 +68,11 @@ def webauthn_begin_activate():
     if User.query.filter_by(username=username).first():
         return make_response(jsonify({'fail': 'User already exists.'}), 401)
 
-    if 'register_ukey' in session:
-        del session['register_ukey']
-    if 'register_username' in session:
-        del session['register_username']
-    if 'register_display_name' in session:
-        del session['register_display_name']
-    if 'challenge' in session:
-        del session['challenge']
+    #clear session variables prior to starting a new registration
+    session.pop('register_ukey', None)
+    session.pop('register_username', None)
+    session.pop('register_display_name', None)
+    session.pop('challenge', None)
 
     session['register_username'] = username
     session['register_display_name'] = display_name
@@ -108,8 +105,7 @@ def webauthn_begin_assertion():
     if not user.credential_id:
         return make_response(jsonify({'fail': 'Unknown credential ID.'}), 401)
 
-    if 'challenge' in session:
-        del session['challenge']
+    session.pop('challenge', None)
 
     challenge = util.generate_challenge(32)
 

--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -32,6 +32,7 @@ login_manager = LoginManager()
 login_manager.init_app(app)
 
 RP_ID = 'localhost'
+RP_NAME = 'localhost'
 ORIGIN = 'https://localhost:5000'
 
 # Trust anchors (trusted attestation roots) should be
@@ -77,7 +78,6 @@ def webauthn_begin_activate():
     session['register_username'] = username
     session['register_display_name'] = display_name
 
-    rp_name = 'localhost'
     challenge = util.generate_challenge(32)
     ukey = util.generate_ukey()
 
@@ -85,7 +85,7 @@ def webauthn_begin_activate():
     session['register_ukey'] = ukey
 
     make_credential_options = webauthn.WebAuthnMakeCredentialOptions(
-        challenge, rp_name, RP_ID, ukey, username, display_name,
+        challenge, RP_NAME, RP_ID, ukey, username, display_name,
         'https://example.com')
 
     return jsonify(make_credential_options.registration_dict)

--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -32,7 +32,7 @@ login_manager = LoginManager()
 login_manager.init_app(app)
 
 RP_ID = 'localhost'
-RP_NAME = 'localhost'
+RP_NAME = 'webauthn demo localhost'
 ORIGIN = 'https://localhost:5000'
 
 # Trust anchors (trusted attestation roots) should be

--- a/flask_demo/static/js/webauthn.js
+++ b/flask_demo/static/js/webauthn.js
@@ -100,7 +100,7 @@ const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) =
     let {challenge, allowCredentials} = credentialRequestOptionsFromServer;
 
     challenge = Uint8Array.from(
-        atob(challenge), c => c.charCodeAt(0));
+        atob(challenge.replace(/\_/g, "/").replace(/\-/g, "+")), c => c.charCodeAt(0));
 
     allowCredentials = allowCredentials.map(credentialDescriptor => {
         let {id} = credentialDescriptor;
@@ -141,10 +141,18 @@ const getCredentialCreateOptionsFromServer = async (formData) => {
 const transformCredentialCreateOptions = (credentialCreateOptionsFromServer) => {
     let {challenge, user} = credentialCreateOptionsFromServer;
     user.id = Uint8Array.from(
-        atob(credentialCreateOptionsFromServer.user.id), c => c.charCodeAt(0));
+        atob(credentialCreateOptionsFromServer.user.id
+            .replace(/\_/g, "/")
+            .replace(/\-/g, "+")
+            ), 
+        c => c.charCodeAt(0));
 
     challenge = Uint8Array.from(
-        atob(credentialCreateOptionsFromServer.challenge), c => c.charCodeAt(0));
+        atob(credentialCreateOptionsFromServer.challenge
+            .replace(/\_/g, "/")
+            .replace(/\-/g, "+")
+            ),
+        c => c.charCodeAt(0));
     
     const transformedCredentialCreateOptions = Object.assign(
             {}, credentialCreateOptionsFromServer,

--- a/flask_demo/static/js/webauthn.js
+++ b/flask_demo/static/js/webauthn.js
@@ -47,7 +47,7 @@ const didClickRegister = async (e) => {
     try {
         credentialCreateOptionsFromServer = await getCredentialCreateOptionsFromServer(formData);
     } catch (err) {
-        return console.error("Failed to generate credential request options:", credentialCreateOptionsFromServer)
+        return console.error("Failed to generate credential request options:", err);
     }
 
     // convert certain members of the PublicKeyCredentialCreateOptions into


### PR DESCRIPTION
Errata:
webauthn.js line 50: catch clause should log `err` to console, not `credentialCreateOptionsFromServer`
`credentialCreateOptionsFromServer` is undefined in the catch clause.

Base 64 handling:
call `replace()` to translate websafe base64 encoding to standard base64 encoding. This commit enables webauthn.js to support websafe base64 challenge strings.

As demonstrated in pull request #8, resubmitting pull request #66 with commits on a separate branch. 