### PR TITLE
Flask demo client-side js 

### DIFF
--- a/flask_demo/static/js/webauthn.js
+++ b/flask_demo/static/js/webauthn.js
@@ -100,7 +100,7 @@ const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) =
     let {challenge, allowCredentials} = credentialRequestOptionsFromServer;
 
     challenge = Uint8Array.from(
-        atob(challenge), c => c.charCodeAt(0));
+        atob(challenge.replace(/\_/g, "/").replace(/\-/g, "+")), c => c.charCodeAt(0));
 
     allowCredentials = allowCredentials.map(credentialDescriptor => {
         let {id} = credentialDescriptor;
@@ -141,10 +141,18 @@ const getCredentialCreateOptionsFromServer = async (formData) => {
 const transformCredentialCreateOptions = (credentialCreateOptionsFromServer) => {
     let {challenge, user} = credentialCreateOptionsFromServer;
     user.id = Uint8Array.from(
-        atob(credentialCreateOptionsFromServer.user.id), c => c.charCodeAt(0));
+        atob(credentialCreateOptionsFromServer.user.id
+            .replace(/\_/g, "/")
+            .replace(/\-/g, "+")
+            ), 
+        c => c.charCodeAt(0));
 
     challenge = Uint8Array.from(
-        atob(credentialCreateOptionsFromServer.challenge), c => c.charCodeAt(0));
+        atob(credentialCreateOptionsFromServer.challenge
+            .replace(/\_/g, "/")
+            .replace(/\-/g, "+")
+            ),
+        c => c.charCodeAt(0));
     
     const transformedCredentialCreateOptions = Object.assign(
             {}, credentialCreateOptionsFromServer,

--- a/flask_demo/static/js/webauthn.js
+++ b/flask_demo/static/js/webauthn.js
@@ -47,7 +47,7 @@ const didClickRegister = async (e) => {
     try {
         credentialCreateOptionsFromServer = await getCredentialCreateOptionsFromServer(formData);
     } catch (err) {
-        return console.error("Failed to generate credential request options:", credentialCreateOptionsFromServer)
+        return console.error("Failed to generate credential request options:", err);
     }
 
     // convert certain members of the PublicKeyCredentialCreateOptions into


### PR DESCRIPTION
`getCredentialCreateOptionsFromServer` and `getCredentialRequestOptionsFromServer` differ only by a hardcoded url. The same applies to `postAssertionToServer` and `postNewAssertionToServer`. These functions can be consolidated into functions that takes the url as a parameter.

This change is to improve readability. The destination urls have been moved to the main body of `didClickRegister` and `didClickLogin` to help the reader more easily identify the server-side function being invoked at each step of the registration or authentication process. In short, the information is all in one place. Having less code to review should also be a plus for the readability factor. 

A future improvement may be to use Flask templating and [url_for](https://flask.palletsprojects.com/en/1.1.x/api/#flask.url_for) to insert the appropriate urls at runtime. 

commits prior to [da4a230](https://github.com/duo-labs/py_webauthn/commit/da4a230f473321eff411452b1b764408f00b7497) are duplicated from #67