### PR TITLE
Fix demo challenge randomness, restructure tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,4 +29,4 @@ jobs:
         pip install -r flask_demo/requirements.txt
     - name: Test with unittest
       run: |
-        python -m unittest tests/webauthn_test.py
+        python -m unittest

--- a/README.rst
+++ b/README.rst
@@ -150,9 +150,11 @@ For Firefox, you should be able to proceed to the page being served by the Flask
 Unit Tests
 ==========
 
-To run the unit tests, use the following command:
+To run the unit tests, use the following command from the top directory:
 
-``python3 -m unittest tests/webauthn_test.py``
+``python3 -m unittest``
+
+This will run both the `py_webauthn` library tests and the Flask demo tests.
 
 Note
 ====

--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -114,7 +114,7 @@ def webauthn_begin_assertion():
 
     challenge = util.generate_challenge(32)
 
-    session['challenge'] = challenge
+    session['challenge'] = challenge.rstrip('=')
 
     webauthn_user = webauthn.WebAuthnUser(
         user.ukey, user.username, user.display_name, user.icon_url,

--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -114,6 +114,8 @@ def webauthn_begin_assertion():
 
     challenge = util.generate_challenge(32)
 
+    # We strip the padding from the challenge stored in the session
+    # for the reasons outlined in the comment in webauthn_begin_activate.
     session['challenge'] = challenge.rstrip('=')
 
     webauthn_user = webauthn.WebAuthnUser(

--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -81,7 +81,12 @@ def webauthn_begin_activate():
     challenge = util.generate_challenge(32)
     ukey = util.generate_ukey()
 
-    session['challenge'] = challenge
+    # We strip the saved challenge of padding, so that we can do a byte
+    # comparison on the URL-safe-without-padding challenge we get back
+    # from the browser.
+    # We will still pass the padded version down to the browser so that the JS
+    # can decode the challenge into binary without too much trouble.
+    session['challenge'] = challenge.rstrip('=')
     session['register_ukey'] = ukey
 
     make_credential_options = webauthn.WebAuthnMakeCredentialOptions(

--- a/flask_demo/util.py
+++ b/flask_demo/util.py
@@ -32,9 +32,11 @@ def validate_display_name(display_name):
 
 def generate_challenge(challenge_len):
     '''Generate a challenge of challenge_len bytes, Base64-encoded.
-    We use the weird URL-safe base64 without padding that is specified in the
-    WebAuthn spec. The output of this function is passed directly to the web client,
-    which will have to add the padding back in if it wants to use `atob`.
+    We use URL-safe base64, but we *don't* strip the padding, so that
+    the browser can decode it without too much hassle.
+    Note that if we are doing byte comparisons with the challenge in collectedClientData
+    later on, that value will not have padding, so we must remove the padding
+    before storing the value in the session.
     '''
     # If we know Python 3.6 or greater is available, we could replace this with one
     # call to secrets.token_urlsafe
@@ -43,7 +45,7 @@ def generate_challenge(challenge_len):
     # Python 2/3 compatibility: b64encode returns bytes only in newer Python versions
     if not isinstance(challenge_base64, str):
         challenge_base64 = challenge_base64.decode('utf-8')
-    return challenge_base64.rstrip('=')
+    return challenge_base64
 
 
 def generate_ukey():

--- a/flask_demo/util.py
+++ b/flask_demo/util.py
@@ -4,11 +4,16 @@ import string
 import os
 import base64
 
+CHALLENGE_DEFAULT_BYTE_LEN = 32
+UKEY_DEFAULT_BYTE_LEN = 20
+USERNAME_MAX_LENGTH = 32
+DISPLAY_NAME_MAX_LENGTH = 65
+
 def validate_username(username):
     if not isinstance(username, six.string_types):
         return False
 
-    if len(username) > 32:
+    if len(username) > USERNAME_MAX_LENGTH:
         return False
 
     if not username.isalnum():
@@ -21,7 +26,7 @@ def validate_display_name(display_name):
     if not isinstance(display_name, six.string_types):
         return False
 
-    if len(display_name) > 65:
+    if len(display_name) > DISPLAY_NAME_MAX_LENGTH:
         return False
 
     if not display_name.replace(' ', '').isalnum():
@@ -30,7 +35,7 @@ def validate_display_name(display_name):
     return True
 
 
-def generate_challenge(challenge_len):
+def generate_challenge(challenge_len=CHALLENGE_DEFAULT_BYTE_LEN):
     '''Generate a challenge of challenge_len bytes, Base64-encoded.
     We use URL-safe base64, but we *don't* strip the padding, so that
     the browser can decode it without too much hassle.
@@ -60,4 +65,4 @@ def generate_ukey():
     sets the RP ID. For a user account entity, this will be an
     arbitrary string specified by the relying party.
     '''
-    return generate_challenge(20)
+    return generate_challenge(UKEY_DEFAULT_BYTE_LEN)

--- a/flask_demo/util.py
+++ b/flask_demo/util.py
@@ -1,7 +1,8 @@
 import random
 import six
 import string
-
+import os
+import base64
 
 def validate_username(username):
     if not isinstance(username, six.string_types):
@@ -30,10 +31,19 @@ def validate_display_name(display_name):
 
 
 def generate_challenge(challenge_len):
-    return ''.join([
-        random.SystemRandom().choice(string.ascii_letters + string.digits)
-        for i in range(challenge_len)
-    ])
+    '''Generate a challenge of challenge_len bytes, Base64-encoded.
+    We use the weird URL-safe base64 without padding that is specified in the
+    WebAuthn spec. The output of this function is passed directly to the web client,
+    which will have to add the padding back in if it wants to use `atob`.
+    '''
+    # If we know Python 3.6 or greater is available, we could replace this with one
+    # call to secrets.token_urlsafe
+    challenge_bytes = os.urandom(challenge_len)
+    challenge_base64 = base64.urlsafe_b64encode(challenge_bytes)
+    # Python 2/3 compatibility: b64encode returns bytes only in newer Python versions
+    if not isinstance(challenge_base64, str):
+        challenge_base64 = challenge_base64.decode('utf-8')
+    return challenge_base64.rstrip('=')
 
 
 def generate_ukey():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,24 @@
+import unittest
+import base64
+from flask_demo import util
+import binascii
+
+CHALLENGE_BYTE_LENGTH = 32
+
+class EncodingTests(unittest.TestCase):
+    def test_confirm_padded(self):
+        '''Ensure that generate_challenge correctly generates *padded* URL-safe base64.'''
+        challenge_padded = util.generate_challenge(CHALLENGE_BYTE_LENGTH)
+        try:
+            base64.urlsafe_b64decode(challenge_padded) # expects padded challenge
+        except binascii.Error:
+            self.fail("generate_challenge didn't produced padded base64")
+    
+    def test_confirm_byte_length(self):
+        '''Ensure that generate_challenge produces values of the proper byte length.'''
+        challenge_padded = util.generate_challenge(CHALLENGE_BYTE_LENGTH)
+        challenge_bytes = base64.urlsafe_b64decode(challenge_padded)
+        self.assertEqual(len(challenge_bytes), CHALLENGE_BYTE_LENGTH)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,13 +2,15 @@ import unittest
 import base64
 from flask_demo import util
 import binascii
-
-CHALLENGE_BYTE_LENGTH = 32
+from unittest.mock import patch
+import sys
 
 class EncodingTests(unittest.TestCase):
     def test_confirm_padded(self):
-        '''Ensure that generate_challenge correctly generates *padded* URL-safe base64.'''
-        challenge_padded = util.generate_challenge(CHALLENGE_BYTE_LENGTH)
+        '''Ensure that generate_challenge correctly generates *padded* URL-safe base64.
+        If a 32-byte challenge is requested, it will always have a single padding character,
+        so we can trust that the decode will fail if padding is omitted.'''
+        challenge_padded = util.generate_challenge()
         try:
             base64.urlsafe_b64decode(challenge_padded) # expects padded challenge
         except binascii.Error:
@@ -16,9 +18,9 @@ class EncodingTests(unittest.TestCase):
     
     def test_confirm_byte_length(self):
         '''Ensure that generate_challenge produces values of the proper byte length.'''
-        challenge_padded = util.generate_challenge(CHALLENGE_BYTE_LENGTH)
+        challenge_padded = util.generate_challenge()
         challenge_bytes = base64.urlsafe_b64decode(challenge_padded)
-        self.assertEqual(len(challenge_bytes), CHALLENGE_BYTE_LENGTH)
+        self.assertEqual(len(challenge_bytes), util.CHALLENGE_DEFAULT_BYTE_LEN)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -1,13 +1,10 @@
 import os
 import unittest
 import struct
-
 from copy import copy
 
 import webauthn
-
 from webauthn import const
-
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 TRUST_ANCHOR_DIR = "{}/../webauthn/trusted_attestation_roots".format(HERE)


### PR DESCRIPTION
In the Flask demo, previously, we were generating challenges by randomly pulling from the URLsafe base64 alphabet.

Ideally we should be generating cryptographically random challenges in bytes, and then encoding them. This change does that. The generate_challenge utility function will generate a *padded* base64url-encoded challenge. This challenge is the one that will be shipped down to the browser, and the padding is kept intact for easy decoding. Before the challenge is stored in the session object, it will be stripped of padding, since the padding value we receive from the browser in the form of CollectedClientData will be base64url-encoded with no padding.