### PR TITLE
flask demo: webauthn origin mismatch

### DIFF
--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -33,7 +33,9 @@ login_manager.init_app(app)
 
 RP_ID = 'localhost'
 RP_NAME = 'webauthn demo localhost'
-ORIGIN = 'https://localhost:5000'
+FLASK_HOST = 'localhost'
+FLASK_PORT = '5000'
+ORIGIN = 'https://{host}:{port}'.format(host=FLASK_HOST, port=FLASK_PORT)
 
 # Trust anchors (trusted attestation roots) should be
 # placed in TRUST_ANCHOR_DIR.
@@ -246,4 +248,4 @@ def logout():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', ssl_context='adhoc', debug=True)
+    app.run(host=FLASK_HOST, port=FLASK_PORT, ssl_context='adhoc', debug=True)


### PR DESCRIPTION
Starting the flask server at '0.0.0.0' causes an origin mismatch for some browsers. Though 'https://0.0.0.0:5000' and 'https://localhost:5000' are both ways to navigate to the same server, the browser may treat these as separate origins and disallow webauthn operations. This change ensures that the flask server's hostname matches the expected origin of the webauthn credential. This change also enables the server to run on a different port.

This commit requires testing on more browsers. 

The choice to build the origin string from the host and port vs. parsing the host and port out of a complete origin string was arbitrary. 