### PR TITLE
Update Readme, address browser security mechanism - but not as issues..

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,16 +134,21 @@ To run the `Flask <http://flask.pocoo.org/>`_ demo with `Docker <https://www.doc
 
 Demo Troubleshooting
 ====================
-By default, both the local and Docker demos try to run the web app using HTTPS. This may cause issues such as
-``NET::ERR_CERT_AUTHORITY_INVALID`` on Chrome. To get around this issue on Chrome, you can do the following:
+By default, both the local and Docker demos try to run the web app using HTTPS. You may see a security mechanism such as
+``NET::ERR_CERT_AUTHORITY_INVALID`` (on Chrome). For a operating system wide solution you may use ``security add-trusted-cert``
+on Mac OS X or; ``certutil -addstore`` on Windows or; ``libnss3-tools`` apt package, ``nss-tools`` yum package, ``mozilla-nss-tools``
+zypper package n Linux.
+
+Alternatively to get around this security mechanism on Chrome only, you can do the following:
 
 #. Generate a self-signed certificate through tools like mkcert_
-#. Enable requests to localhost over HTTPS through the following flag: ``chrome://flags/#allow-insecure-localhost``.
+#. Install Client Digital Certificate (Using Chrome) go to Settings > Show Advanced Settings > Manage Certificates OR;
+#. Avoid TLS security on your computer (localhost) entirely and allow any requests over HTTPS; enable ``chrome://flags/#allow-insecure-localhost``.
 
 For Firefox, you should be able to proceed to the page being served by the Flask app by doing the following:
 
-#. Clicking 'Advanced'
-#. Clicking 'Accept the Risk and Continue'.
+#. Install Client Digital Certificate (Using Firefox) go to Options > Privacy & Security > Certificates > View Certificates. In Certificate Manager click ``Import`` under ``Authorities`` tab. OR;
+#. Avoid TLS security when you load the page, you can Click 'Advanced' then chose 'Accept the Risk and Continue'.
 
 .. _mkcert: https://github.com/FiloSottile/mkcert
 


### PR DESCRIPTION
Avoid language to imply there are _issues_ with browser security, simply describe the security mechanism to the reader as they are not _issues_.

Prefer to **not** encourage readers to disable security features in browsers as the first option.

Lead more technical users to operating system certificate trust store utilities to manage self-signed certificates for all install browsers, they are after all already capable of generating the certificate so let's not treat the reader as incapable to properly manage them also (which is far less technical, point-and-click).

Provide more accurate language for when you are circumventing TLS security, and the wider implications of the instruction that leaves you vulnerable beyond the Flask demo app.