### PR TITLE
fix/safetynet-unit-test-failure

### DIFF
--- a/tests/test_verify_registration_response_android_safetynet.py
+++ b/tests/test_verify_registration_response_android_safetynet.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 from webauthn.helpers import parse_attestation_object
 from webauthn.helpers.structs import RegistrationCredential
@@ -8,7 +9,15 @@ from webauthn.registration.formats.android_safetynet import (
 
 
 class TestVerifyRegistrationResponseAndroidSafetyNet(TestCase):
-    def test_verify_attestation_android_safetynet(self) -> None:
+    # TODO: Revisit these tests when we figure out how to generate dynamic certs that
+    # won't start failing tests 72 hours after creation...
+    @patch("OpenSSL.crypto.X509StoreContext.verify_certificate")
+    def test_verify_attestation_android_safetynet(
+        self, mock_verify_certificate: MagicMock
+    ) -> None:
+        # Mocked because these certs actually expired and started failing this test
+        mock_verify_certificate.return_value = True
+
         credential = RegistrationCredential.parse_raw(
             """{
             "id": "AePltP2wAoNYwG5XGc9sfleGgDxQRHdkX8vphNIHv3HylIj_nZo9ncs7bLL65AGmVAc69pS4l64hgOBJU9o2jCQ",


### PR DESCRIPTION
A certificate in the SafetyNet responses's x5c expired this morning:

![Screen Shot 2021-10-17 at 9 29 02 PM](https://user-images.githubusercontent.com/5166470/137670865-a95849b7-c889-4aa6-b495-f4263ae307c3.png)

This diff patches certification chain verification at the pyOpenSSL level so that the verification always passes, following a pattern used in other attestation-statement-specific unit tests that also fail because their certs are short-lived.