### PR TITLE
safetynet-time-drift

### DIFF
--- a/tests/test_verify_safetynet_timestamp.py
+++ b/tests/test_verify_safetynet_timestamp.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from webauthn.helpers import verify_safetynet_timestamp
+
+
+class TestVerifySafetyNetTimestamp(TestCase):
+    mock_time: MagicMock
+    # time.time() returns time in microseconds
+    mock_now = 1636589648
+
+    def setUp(self) -> None:
+        super().setUp()
+        time_patch = patch("time.time")
+        self.mock_time = time_patch.start()
+        self.mock_time.return_value = self.mock_now
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        patch.stopall()
+
+    def test_does_not_raise_on_timestamp_slightly_in_future(self):
+        # Put timestamp just a bit in the future
+        timestamp_ms = (self.mock_now * 1000) + 600
+        verify_safetynet_timestamp(timestamp_ms)
+
+        assert True
+
+    def test_does_not_raise_on_timestamp_slightly_in_past(self):
+        # Put timestamp just a bit in the past
+        timestamp_ms = (self.mock_now * 1000) - 600
+        verify_safetynet_timestamp(timestamp_ms)
+
+        assert True
+
+    def test_raises_on_timestamp_too_far_in_future(self):
+        # Put timestamp 20 seconds in the future
+        timestamp_ms = (self.mock_now * 1000) + 20000
+        self.assertRaisesRegex(
+            ValueError,
+            "was later than",
+            lambda: verify_safetynet_timestamp(timestamp_ms),
+        )
+
+    def test_raises_on_timestamp_too_far_in_past(self):
+        # Put timestamp 20 seconds in the past
+        timestamp_ms = (self.mock_now * 1000) - 20000
+        self.assertRaisesRegex(
+            ValueError,
+            "expired",
+            lambda: verify_safetynet_timestamp(timestamp_ms),
+        )
+
+    def test_does_not_raise_on_last_possible_millisecond(self):
+        # Timestamp is verified at the exact last millisecond
+        timestamp_ms = (self.mock_now * 1000) + 10000
+        verify_safetynet_timestamp(timestamp_ms)
+
+        assert True

--- a/webauthn/helpers/__init__.py
+++ b/webauthn/helpers/__init__.py
@@ -13,4 +13,5 @@ from .parse_attestation_object import parse_attestation_object  # noqa: F401
 from .parse_authenticator_data import parse_authenticator_data  # noqa: F401
 from .parse_client_data_json import parse_client_data_json  # noqa: F401
 from .validate_certificate_chain import validate_certificate_chain  # noqa: F401
+from .verify_safetynet_timestamp import verify_safetynet_timestamp  #noqa: F401
 from .verify_signature import verify_signature  # noqa: F401

--- a/webauthn/helpers/verify_safetynet_timestamp.py
+++ b/webauthn/helpers/verify_safetynet_timestamp.py
@@ -17,5 +17,5 @@ def verify_safetynet_timestamp(timestamp_ms: int) -> None:
         )
 
     # Make sure the response arrived within the grace period
-    if (timestamp_ms + grace_ms) < now:
+    if timestamp_ms < (now - grace_ms):
         raise ValueError("Payload has expired")

--- a/webauthn/helpers/verify_safetynet_timestamp.py
+++ b/webauthn/helpers/verify_safetynet_timestamp.py
@@ -1,0 +1,21 @@
+import time
+
+
+def verify_safetynet_timestamp(timestamp_ms: int) -> None:
+    """Handle time drift between this RP and the Google SafetyNet API servers with a window of
+    time within which the response is valid
+    """
+    # Buffer period in ms
+    grace_ms = 10 * 1000
+    # Get "now" in ms
+    now = int(time.time()) * 1000
+
+    # Make sure the response was generated in the past
+    if timestamp_ms > (now + grace_ms):
+        raise ValueError(
+            f"Payload timestamp {timestamp_ms} was later than {now} + {grace_ms}"
+        )
+
+    # Make sure the response arrived within the grace period
+    if (timestamp_ms + grace_ms) < now:
+        raise ValueError("Payload has expired")

--- a/webauthn/helpers/verify_safetynet_timestamp.py
+++ b/webauthn/helpers/verify_safetynet_timestamp.py
@@ -2,7 +2,7 @@ import time
 
 
 def verify_safetynet_timestamp(timestamp_ms: int) -> None:
-    """Handle time drift between this RP and the Google SafetyNet API servers with a window of
+    """Handle time drift between an RP and the Google SafetyNet API servers with a window of
     time within which the response is valid
     """
     # Buffer period in ms

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -16,7 +16,10 @@ from webauthn.helpers import (
     verify_safetynet_timestamp,
     verify_signature,
 )
-from webauthn.helpers.exceptions import InvalidCertificateChain, InvalidRegistrationResponse
+from webauthn.helpers.exceptions import (
+    InvalidCertificateChain,
+    InvalidRegistrationResponse,
+)
 from webauthn.helpers.known_root_certs import globalsign_r2, globalsign_root_ca
 from webauthn.helpers.structs import AttestationStatement, WebAuthnBaseModel
 

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -123,7 +123,7 @@ def verify_android_safetynet(
 
     if not payload.cts_profile_match:
         raise InvalidRegistrationResponse(
-            "Could not verify device integrity (SafetyNet"
+            "Could not verify device integrity (SafetyNet)"
         )
 
     if verify_timestamp_ms:
@@ -134,7 +134,7 @@ def verify_android_safetynet(
 
         if now < payload_ms:
             raise InvalidRegistrationResponse(
-                f"Payload timestamp {payload_ms} was later than {now}"
+                f"Payload timestamp {payload_ms} was later than {now} (SafetyNet)"
             )
 
         # Give a 60-second grace period for the response to have been generated and make it

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -10,7 +10,12 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import NameOID
 
 from webauthn.helpers.cose import COSEAlgorithmIdentifier
-from webauthn.helpers import base64url_to_bytes, validate_certificate_chain, verify_signature
+from webauthn.helpers import (
+    base64url_to_bytes,
+    validate_certificate_chain,
+    verify_safetynet_timestamp,
+    verify_signature,
+)
 from webauthn.helpers.exceptions import InvalidCertificateChain, InvalidRegistrationResponse
 from webauthn.helpers.known_root_certs import globalsign_r2, globalsign_root_ca
 from webauthn.helpers.structs import AttestationStatement, WebAuthnBaseModel
@@ -127,21 +132,10 @@ def verify_android_safetynet(
         )
 
     if verify_timestamp_ms:
-        # Verify timestampMs
-        # Get "now" in Unix epoch milliseconds
-        now = int(time.time()) * 1000
-        payload_ms = payload.timestamp_ms
-
-        if now < payload_ms:
-            raise InvalidRegistrationResponse(
-                f"Payload timestamp {payload_ms} was later than {now} (SafetyNet)"
-            )
-
-        # Give a 60-second grace period for the response to have been generated and make it
-        # here to the server
-        payload_ms_grace = payload_ms + (60 * 1000)
-        if payload_ms_grace < now:
-            raise InvalidRegistrationResponse("Payload has expired (SafetyNet)")
+        try:
+            verify_safetynet_timestamp(payload.timestamp_ms)
+        except ValueError as err:
+            raise InvalidRegistrationResponse(f"{err} (SafetyNet)")
 
     # Verify that the leaf certificate was issued to the hostname attest.android.com
     attestation_cert = x509.load_der_x509_certificate(x5c[0], default_backend())


### PR DESCRIPTION
Natural time drift between RP and Google SafetyNet API is inevitable, even if it's just a few hundred milliseconds. Unfortunately the library is too strict on timing and will error out on a SafetyNet response that appears to be even a millisecond from the future.

This diff addresses this problem by checking that a SafetyNet response originated sometime between "now +/- 10 seconds".

Addresses #106.