### PR TITLE
typing-pep-561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     name='webauthn',
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
+    package_data={"webauthn": ["py.typed"]},
     version=VERSION,
     description='Pythonic WebAuthn',
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
The issue was raised in #105 that py_webauthn was missing files needed for mypy to understand that the package includes type info. This diff attempts to address this problem by adding a new **py.typed** file to the root package as per [PEP 561](https://www.python.org/dev/peps/pep-0561/). This should allow the next release and beyond to work nicely with tools like mypy.

Addresses #105.