### PR TITLE
feat/attrs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,3 +30,6 @@ jobs:
     - name: Test with unittest
       run: |
         python -m unittest
+    - name: Run mypy
+      run: |
+        python -m mypy webauthn

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "python.pythonPath": "venv/bin/python",
-  "python.linting.mypyEnabled": false,
+  "python.linting.mypyEnabled": true,
   "python.linting.flake8Enabled": false,
   "python.formatting.blackPath": "venv/bin/black",
   "python.linting.enabled": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "python.linting.mypyEnabled": true,
   "python.linting.flake8Enabled": false,
   "python.formatting.blackPath": "venv/bin/black",
+  "python.formatting.provider": "black",
   "python.linting.enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Two additional helper methods are also exposed:
 - `options_to_json()`
 - `base64url_to_bytes()`
 
-Additional data structures are available on `webauthn.helpers.structs`. These are useful for constructing inputs to the methods above, and for type hinting. These [Pydantic-powered](https://pydantic-docs.helpmanual.io/) dataclasses provide runtime data validation to help ensure consistency in the shape of data being passed around.
+Additional data structures are available on `webauthn.helpers.structs`. These [attrs-powered](https://www.attrs.org/) dataclasses are useful for constructing inputs to the methods above, and for providing type hinting to help ensure consistency in the shape of data being passed around.
 
 ### Registration
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+python_version = 3.8
+
+[mypy-asn1crypto.*]
+ignore_missing_imports = True
+
+[mypy-cbor2.*]
+ignore_missing_imports = True
+
+[mypy-OpenSSL.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 asn1crypto==0.24.0
+attrs==21.2.0
 black==21.9b0
+cattrs==1.8.0
 cbor2==4.0.1
 cffi==1.15.0
 click==8.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ cffi==1.15.0
 click==8.0.3
 cryptography==3.4.7
 mccabe==0.6.1
+mypy==0.910
 mypy-extensions==0.4.3
 pathspec==0.9.0
 platformdirs==2.4.0
@@ -16,5 +17,6 @@ pyflakes==2.4.0
 pyOpenSSL==20.0.1
 regex==2021.10.8
 six==1.16.0
+toml==0.10.2
 tomli==1.2.1
 typing-extensions==3.10.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-asn1crypto==0.24.0
+asn1crypto==1.4.0
 attrs==21.2.0
 black==21.9b0
 cattrs==1.8.0
-cbor2==4.0.1
+cbor2==5.4.2
 cffi==1.15.0
 click==8.0.3
-cryptography==3.4.7
+cryptography==3.4.8
 mccabe==0.6.1
 mypy==0.910
 mypy-extensions==0.4.3
@@ -14,7 +14,7 @@ platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
 pyflakes==2.4.0
-pyOpenSSL==20.0.1
+pyOpenSSL==21.0.0
 regex==2021.10.8
 six==1.16.0
 toml==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pathspec==0.9.0
 platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
-pydantic==1.8.2
 pyflakes==2.4.0
 pyOpenSSL==20.0.1
 regex==2021.10.8

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
         'asn1crypto>=0.24.0',
         'cbor2>=4.0.1',
         'cryptography>=3.4.7',
-        'pydantic>=1.8.2',
+        'attrs>=21.2.0',
+        'cattrs>=1.8.0',
         'pyOpenSSL>=20.0.1',
     ]
 )

--- a/tests/test_bytes_subclass_support.py
+++ b/tests/test_bytes_subclass_support.py
@@ -1,0 +1,52 @@
+from unittest import TestCase
+
+from webauthn import verify_authentication_response, base64url_to_bytes
+from webauthn.helpers.structs import (
+    AuthenticationCredential,
+    AuthenticatorAssertionResponse,
+)
+
+
+class CustomBytes(bytes):
+    def __new__(cls, data: str):
+        data_bytes = base64url_to_bytes(data)
+        self = bytes.__new__(cls, memoryview(data_bytes).tobytes())
+        return self
+
+
+class TestWebAuthnBytesSubclassSupport(TestCase):
+    def test_handles_bytes_subclasses(self) -> None:
+        """
+        Ensure the library can support being used in projects that might work with values that are
+        subclasses of `bytes`. Let's embrace Python's duck-typing, not shy away from it
+        """
+        verification = verify_authentication_response(
+            credential=AuthenticationCredential(
+                id="fq9Nj0nS24B5y6Pkw_h3-9GEAEA3-0LBPxE2zvTdLjDqtSeCSNYFe9VMRueSpAZxT3YDc6L1lWXdQNwI-sVNYrefEcRR1Nsb_0jpHE955WEtFud2xxZg3MvoLMxHLet63i5tajd1fHtP7I-00D6cehM8ZWlLp2T3s9lfZgVIFcA",
+                raw_id=CustomBytes(
+                    "fq9Nj0nS24B5y6Pkw_h3-9GEAEA3-0LBPxE2zvTdLjDqtSeCSNYFe9VMRueSpAZxT3YDc6L1lWXdQNwI-sVNYrefEcRR1Nsb_0jpHE955WEtFud2xxZg3MvoLMxHLet63i5tajd1fHtP7I-00D6cehM8ZWlLp2T3s9lfZgVIFcA"
+                ),
+                response=AuthenticatorAssertionResponse(
+                    authenticator_data=CustomBytes(
+                        "SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MBAAAABw"
+                    ),
+                    client_data_json=CustomBytes(
+                        "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiZVo0ZWVBM080ank1Rkl6cURhU0o2SkROR3UwYkJjNXpJMURqUV9rTHNvMVdOcWtHNms1bUNZZjFkdFFoVlVpQldaV2xaa3pSNU1GZWVXQ3BKUlVOWHciLCJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjUwMDAiLCJjcm9zc09yaWdpbiI6ZmFsc2V9"
+                    ),
+                    signature=CustomBytes(
+                        "RRWV8mYDRvK7YdQgdtZD4pJ2dh1D_IWZ_D6jsZo6FHJBoenbj0CVT5nA20vUzlRhN4R6dOEUHmUwP1F8eRBhBg"
+                    ),
+                ),
+            ),
+            expected_challenge=CustomBytes(
+                "eZ4eeA3O4jy5FIzqDaSJ6JDNGu0bBc5zI1DjQ_kLso1WNqkG6k5mCYf1dtQhVUiBWZWlZkzR5MFeeWCpJRUNXw"
+            ),
+            expected_rp_id="localhost",
+            expected_origin="http://localhost:5000",
+            credential_public_key=CustomBytes(
+                "pAEBAycgBiFYIMz6_SUFLiDid2Yhlq0YboyJ-CDrIrNpkPUGmJp4D3Dp"
+            ),
+            credential_current_sign_count=3,
+        )
+
+        assert verification.new_sign_count == 7

--- a/tests/test_options_to_json.py
+++ b/tests/test_options_to_json.py
@@ -7,6 +7,7 @@ from webauthn.helpers.structs import (
     AttestationConveyancePreference,
     AuthenticatorAttachment,
     AuthenticatorSelectionCriteria,
+    AuthenticatorTransport,
     PublicKeyCredentialDescriptor,
     ResidentKeyRequirement,
 )
@@ -55,3 +56,25 @@ class TestWebAuthnOptionsToJSON(TestCase):
             },
             "attestation": "direct",
         }
+
+    def test_includes_optional_value_when_set(self) -> None:
+        options = generate_registration_options(
+            rp_id="example.com",
+            rp_name="Example Co",
+            user_id="ABAV6QWPBEY9WOTOA1A4",
+            user_name="lee",
+            exclude_credentials=[
+                PublicKeyCredentialDescriptor(
+                    id=b"1234567890",
+                    transports=[AuthenticatorTransport.USB],
+                )
+            ],
+        )
+
+        output = options_to_json(options)
+
+        assert json.loads(output)["excludeCredentials"] == [{
+            "id": "MTIzNDU2Nzg5MA",
+            "transports": ["usb"],
+            "type": "public-key",
+        }]

--- a/tests/test_verify_registration_response.py
+++ b/tests/test_verify_registration_response.py
@@ -86,7 +86,7 @@ class TestVerifyRegistrationResponse(TestCase):
         expected_origin = "http://localhost:5000"
 
         with self.assertRaisesRegex(
-            Exception, "value is not a valid enumeration member"
+            Exception, "Unsupported attestation type"
         ):
             verify_registration_response(
                 credential=credential,

--- a/tests/test_verify_registration_response_fido_u2f.py
+++ b/tests/test_verify_registration_response_fido_u2f.py
@@ -90,17 +90,15 @@ class TestVerifyRegistrationResponseFIDOU2F(TestCase):
         rp_id = "duo.test"
         expected_origin = "https://api-duo1.duo.test"
 
-        verification = verify_registration_response(
-            credential=credential,
-            expected_challenge=challenge,
-            expected_origin=expected_origin,
-            expected_rp_id=rp_id,
-        )
-
-        assert verification.fmt == AttestationFormat.FIDO_U2F
-        assert verification.credential_id == base64url_to_bytes(
-            "JeC3qgQjIVysq88GxhGUYyDl4oZeW8mLWd7luJWQvnrm-wxGZ5mzf2bBCaUDq7D2qr4aQezvzfoFIF880ciAsQ",
-        )
+        with self.assertRaisesRegex(
+            Exception, "Unexpected token_binding status"
+        ):
+            verify_registration_response(
+                credential=credential,
+                expected_challenge=challenge,
+                expected_origin=expected_origin,
+                expected_rp_id=rp_id,
+            )
 
     def test_verify_attestation_with_unsupported_token_binding(self) -> None:
         # Credential contains `clientDataJSON: { tokenBinding: "unused" }`

--- a/webauthn/__init__.py
+++ b/webauthn/__init__.py
@@ -1,7 +1,11 @@
 from .registration.generate_registration_options import generate_registration_options
 from .registration.verify_registration_response import verify_registration_response
-from .authentication.generate_authentication_options import generate_authentication_options
-from .authentication.verify_authentication_response import verify_authentication_response
+from .authentication.generate_authentication_options import (
+    generate_authentication_options,
+)
+from .authentication.verify_authentication_response import (
+    verify_authentication_response,
+)
 from .helpers import base64url_to_bytes, options_to_json
 
 __version__ = "1.1.0"

--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -114,9 +114,9 @@ def verify_authentication_response(
     # Generate a hash of the expected RP ID for comparison
     expected_rp_id_hash = hashlib.sha256()
     expected_rp_id_hash.update(expected_rp_id.encode("utf-8"))
-    expected_rp_id_hash = expected_rp_id_hash.digest()
+    expected_rp_id_hash_bytes = expected_rp_id_hash.digest()
 
-    if auth_data.rp_id_hash != expected_rp_id_hash:
+    if auth_data.rp_id_hash != expected_rp_id_hash_bytes:
         raise InvalidAuthenticationResponse("Unexpected RP ID hash")
 
     if not auth_data.flags.up:
@@ -141,9 +141,9 @@ def verify_authentication_response(
 
     client_data_hash = hashlib.sha256()
     client_data_hash.update(response.client_data_json)
-    client_data_hash = client_data_hash.digest()
+    client_data_hash_bytes = client_data_hash.digest()
 
-    signature_base = response.authenticator_data + client_data_hash
+    signature_base = response.authenticator_data + client_data_hash_bytes
 
     try:
         decoded_public_key = decode_credential_public_key(credential_public_key)

--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -1,6 +1,7 @@
 import hashlib
 from typing import List, Union
 
+from attr import define
 from cryptography.exceptions import InvalidSignature
 
 from webauthn.helpers import (
@@ -17,11 +18,11 @@ from webauthn.helpers.structs import (
     ClientDataType,
     PublicKeyCredentialType,
     TokenBindingStatus,
-    WebAuthnBaseModel,
 )
 
 
-class VerifiedAuthentication(WebAuthnBaseModel):
+@define
+class VerifiedAuthentication:
     """
     Information about a verified authentication of which an RP can make use
     """

--- a/webauthn/helpers/__init__.py
+++ b/webauthn/helpers/__init__.py
@@ -13,5 +13,5 @@ from .parse_attestation_object import parse_attestation_object  # noqa: F401
 from .parse_authenticator_data import parse_authenticator_data  # noqa: F401
 from .parse_client_data_json import parse_client_data_json  # noqa: F401
 from .validate_certificate_chain import validate_certificate_chain  # noqa: F401
-from .verify_safetynet_timestamp import verify_safetynet_timestamp  #noqa: F401
+from .verify_safetynet_timestamp import verify_safetynet_timestamp  # noqa: F401
 from .verify_signature import verify_signature  # noqa: F401

--- a/webauthn/helpers/__init__.py
+++ b/webauthn/helpers/__init__.py
@@ -8,6 +8,7 @@ from .decoded_public_key_to_cryptography import (  # noqa: F401
 from .generate_challenge import generate_challenge  # noqa: F401
 from .generate_user_handle import generate_user_handle  # noqa: F401
 from .hash_by_alg import hash_by_alg  # noqa: F401
+from .json_loads_base64url_to_bytes import json_loads_base64url_to_bytes  # noqa: F401
 from .options_to_json import options_to_json  # noqa: F401
 from .parse_attestation_object import parse_attestation_object  # noqa: F401
 from .parse_authenticator_data import parse_authenticator_data  # noqa: F401

--- a/webauthn/helpers/decode_credential_public_key.py
+++ b/webauthn/helpers/decode_credential_public_key.py
@@ -1,20 +1,22 @@
 from typing import Union
 
+from attr import define
 from cbor2 import decoder
-from pydantic import BaseModel
 
 from .cose import COSECRV, COSEKTY, COSEAlgorithmIdentifier, COSEKey
 from .exceptions import InvalidPublicKeyStructure, UnsupportedPublicKeyType
 
 
-class DecodedOKPPublicKey(BaseModel):
+@define
+class DecodedOKPPublicKey:
     kty: COSEKTY
     alg: COSEAlgorithmIdentifier
     crv: COSECRV
     x: bytes
 
 
-class DecodedEC2PublicKey(BaseModel):
+@define
+class DecodedEC2PublicKey:
     kty: COSEKTY
     alg: COSEAlgorithmIdentifier
     crv: COSECRV
@@ -22,7 +24,8 @@ class DecodedEC2PublicKey(BaseModel):
     y: bytes
 
 
-class DecodedRSAPublicKey(BaseModel):
+@define
+class DecodedRSAPublicKey:
     kty: COSEKTY
     alg: COSEAlgorithmIdentifier
     n: bytes

--- a/webauthn/helpers/json_loads_base64url_to_bytes.py
+++ b/webauthn/helpers/json_loads_base64url_to_bytes.py
@@ -34,6 +34,6 @@ def _object_hook_base64url_to_bytes(orig_dict: dict) -> dict:
 def json_loads_base64url_to_bytes(input: Union[str, bytes]) -> Any:
     """
     Wrap `json.loads()` with a custom object_hook that knows which dict keys to convert
-    from Base64URL to bytes when converting from JSON to Pydantic model
+    from Base64URL to bytes when converting from JSON to a Python class
     """
     return json.loads(input, object_hook=_object_hook_base64url_to_bytes)

--- a/webauthn/helpers/options_to_json.py
+++ b/webauthn/helpers/options_to_json.py
@@ -14,15 +14,19 @@ from .bytes_to_base64url import bytes_to_base64url
 
 
 # Create a converter to convert our attr classes into JSON strings
-converter = make_converter(omit_if_default=True)
+converter = make_converter()
 # Convert snake_case property names to camelCase
 def _to_camel_case_unstructure(cls):
     return make_dict_unstructure_fn(
         cls,
         converter,
         **{
-            a.name: override(rename=snake_case_to_camel_case(a.name))
-            for a in fields(cls)
+            attribute.name: override(
+                # Avoid sending optional `None` defaults as `null` in JSON
+                omit_if_default=attribute.default is None,
+                rename=snake_case_to_camel_case(attribute.name),
+            )
+            for attribute in fields(cls)
         }
     )
 

--- a/webauthn/helpers/options_to_json.py
+++ b/webauthn/helpers/options_to_json.py
@@ -1,9 +1,35 @@
+import json
 from typing import Union
+
+from attr import has, fields
+from cattr.preconf.json import make_converter
+from cattr.gen import make_dict_unstructure_fn, make_dict_structure_fn, override
 
 from .structs import (
     PublicKeyCredentialCreationOptions,
     PublicKeyCredentialRequestOptions,
 )
+from .snake_case_to_camel_case import snake_case_to_camel_case
+from .bytes_to_base64url import bytes_to_base64url
+
+
+# Create a converter to convert our attr classes into JSON strings
+converter = make_converter(omit_if_default=True)
+# Convert snake_case property names to camelCase
+def _to_camel_case_unstructure(cls):
+    return make_dict_unstructure_fn(
+        cls,
+        converter,
+        **{
+            a.name: override(rename=snake_case_to_camel_case(a.name))
+            for a in fields(cls)
+        }
+    )
+
+
+converter.register_unstructure_hook_factory(has, _to_camel_case_unstructure)
+# Encode bytes values to base64url
+converter.register_unstructure_hook(bytes, bytes_to_base64url)
 
 
 def options_to_json(
@@ -15,8 +41,4 @@ def options_to_json(
     """
     Prepare options for transmission to the front end as JSON
     """
-    return options.json(
-        by_alias=True,
-        exclude_unset=False,
-        exclude_none=True,
-    )
+    return json.dumps(converter.unstructure(options))

--- a/webauthn/helpers/parse_client_data_json.py
+++ b/webauthn/helpers/parse_client_data_json.py
@@ -1,8 +1,6 @@
 import json
 from json.decoder import JSONDecodeError
 
-from pydantic import ValidationError
-
 from .base64url_to_bytes import base64url_to_bytes
 from .exceptions import InvalidClientDataJSONStructure
 from .structs import CollectedClientData, TokenBinding
@@ -55,19 +53,14 @@ def parse_client_data_json(val: bytes) -> CollectedClientData:
                 )
 
             status = token_binding_dict["status"]
-            try:
-                # This will raise ValidationError on an unexpected status
-                token_binding = TokenBinding(status=status)
+            # This will raise ValidationError on an unexpected status
+            token_binding = TokenBinding(status=status)
 
-                # Handle optional values
-                if "id" in token_binding_dict:
-                    id = token_binding_dict["id"]
-                    token_binding.id = f"{id}"
+            # Handle optional values
+            if "id" in token_binding_dict:
+                id = token_binding_dict["id"]
+                token_binding.id = f"{id}"
 
-                client_data.token_binding = token_binding
-            except ValidationError:
-                # If we encounter a status we don't expect then ignore token_binding
-                # completely
-                pass
+            client_data.token_binding = token_binding
 
     return client_data

--- a/webauthn/helpers/parse_client_data_json.py
+++ b/webauthn/helpers/parse_client_data_json.py
@@ -53,7 +53,6 @@ def parse_client_data_json(val: bytes) -> CollectedClientData:
                 )
 
             status = token_binding_dict["status"]
-            # This will raise ValidationError on an unexpected status
             token_binding = TokenBinding(status=status)
 
             # Handle optional values

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -1,33 +1,14 @@
 from enum import Enum
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union, Type
+import json
 
-from pydantic import BaseModel
+import attr
+from attr import define
 
 from .bytes_to_base64url import bytes_to_base64url
 from .cose import COSEAlgorithmIdentifier
 from .json_loads_base64url_to_bytes import json_loads_base64url_to_bytes
 from .snake_case_to_camel_case import snake_case_to_camel_case
-
-
-class WebAuthnBaseModel(BaseModel):
-    """
-    A subclass of Pydantic's BaseModel that includes convenient defaults
-    when working with WebAuthn data structures
-
-    `modelInstance.json()` (to JSON):
-    - Encodes bytes to Base64URL
-    - Converts snake_case properties to camelCase
-
-    `Model.parse_raw()` (from JSON):
-    - Decodes Base64URL to bytes
-    - Converts camelCase properties to snake_case
-    """
-
-    class Config:
-        json_encoders = {bytes: bytes_to_base64url}
-        json_loads = json_loads_base64url_to_bytes
-        alias_generator = snake_case_to_camel_case
-        allow_population_by_field_name = True
 
 
 ################
@@ -178,16 +159,18 @@ class TokenBindingStatus(str, Enum):
     SUPPORTED = "supported"
 
 
-class TokenBinding(BaseModel):
+@define
+class TokenBinding:
     """
     https://www.w3.org/TR/webauthn-2/#dictdef-tokenbinding
     """
 
     status: TokenBindingStatus
-    id: Optional[str]
+    id: Optional[str] = None
 
 
-class PublicKeyCredentialRpEntity(WebAuthnBaseModel):
+@define
+class PublicKeyCredentialRpEntity:
     """Information about the Relying Party.
 
     Attributes:
@@ -198,10 +181,11 @@ class PublicKeyCredentialRpEntity(WebAuthnBaseModel):
     """
 
     name: str
-    id: Optional[str]
+    id: Optional[str] = None
 
 
-class PublicKeyCredentialUserEntity(WebAuthnBaseModel):
+@define
+class PublicKeyCredentialUserEntity:
     """Information about a user of a Relying Party.
 
     Attributes:
@@ -217,7 +201,8 @@ class PublicKeyCredentialUserEntity(WebAuthnBaseModel):
     display_name: str
 
 
-class PublicKeyCredentialParameters(WebAuthnBaseModel):
+@define
+class PublicKeyCredentialParameters:
     """Information about a cryptographic algorithm that may be used when creating a credential.
 
     Attributes:
@@ -231,7 +216,8 @@ class PublicKeyCredentialParameters(WebAuthnBaseModel):
     alg: COSEAlgorithmIdentifier
 
 
-class PublicKeyCredentialDescriptor(WebAuthnBaseModel):
+@define
+class PublicKeyCredentialDescriptor:
     """Information about a generated credential.
 
     Attributes:
@@ -242,14 +228,17 @@ class PublicKeyCredentialDescriptor(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialdescriptor
     """
 
+    id: bytes
     type: Literal[
         PublicKeyCredentialType.PUBLIC_KEY
     ] = PublicKeyCredentialType.PUBLIC_KEY
-    id: bytes
-    transports: Optional[List[AuthenticatorTransport]] = None
+    transports: Optional[List[AuthenticatorTransport]] = attr.field(
+        default=attr.Factory(list)
+    )
 
 
-class AuthenticatorSelectionCriteria(WebAuthnBaseModel):
+@define
+class AuthenticatorSelectionCriteria:
     """A Relying Party's requirements for the types of authenticators that may interact with the client/browser.
 
     Attributes:
@@ -261,15 +250,16 @@ class AuthenticatorSelectionCriteria(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#dictdef-authenticatorselectioncriteria
     """
 
-    authenticator_attachment: Optional[AuthenticatorAttachment]
-    resident_key: Optional[ResidentKeyRequirement]
+    authenticator_attachment: Optional[AuthenticatorAttachment] = None
+    resident_key: Optional[ResidentKeyRequirement] = None
     require_resident_key: Optional[bool] = False
     user_verification: Optional[
         UserVerificationRequirement
     ] = UserVerificationRequirement.PREFERRED
 
 
-class CollectedClientData(BaseModel):
+@define
+class CollectedClientData:
     """Decoded ClientDataJSON
 
     Attributes:
@@ -285,8 +275,8 @@ class CollectedClientData(BaseModel):
     type: ClientDataType
     challenge: bytes
     origin: str
-    cross_origin: Optional[bool]
-    token_binding: Optional[TokenBinding]
+    cross_origin: Optional[bool] = None
+    token_binding: Optional[TokenBinding] = None
 
 
 ################
@@ -296,7 +286,8 @@ class CollectedClientData(BaseModel):
 ################
 
 
-class PublicKeyCredentialCreationOptions(WebAuthnBaseModel):
+@define
+class PublicKeyCredentialCreationOptions:
     """Registration Options.
 
     Attributes:
@@ -316,13 +307,14 @@ class PublicKeyCredentialCreationOptions(WebAuthnBaseModel):
     user: PublicKeyCredentialUserEntity
     challenge: bytes
     pub_key_cred_params: List[PublicKeyCredentialParameters]
-    timeout: Optional[int]
-    exclude_credentials: Optional[List[PublicKeyCredentialDescriptor]]
-    authenticator_selection: Optional[AuthenticatorSelectionCriteria]
+    timeout: Optional[int] = None
+    exclude_credentials: Optional[List[PublicKeyCredentialDescriptor]] = None
+    authenticator_selection: Optional[AuthenticatorSelectionCriteria] = None
     attestation: AttestationConveyancePreference = AttestationConveyancePreference.NONE
 
 
-class AuthenticatorAttestationResponse(WebAuthnBaseModel):
+@define
+class AuthenticatorAttestationResponse:
     """The `response` property on a registration credential.
 
     Attributes:
@@ -336,7 +328,8 @@ class AuthenticatorAttestationResponse(WebAuthnBaseModel):
     attestation_object: bytes
 
 
-class RegistrationCredential(WebAuthnBaseModel):
+@define
+class RegistrationCredential:
     """A registration-specific subclass of PublicKeyCredential returned from `navigator.credentials.create()`
 
     Attributes:
@@ -352,13 +345,27 @@ class RegistrationCredential(WebAuthnBaseModel):
     id: str
     raw_id: bytes
     response: AuthenticatorAttestationResponse
+    transports: Optional[List[AuthenticatorTransport]] = None
     type: Literal[
         PublicKeyCredentialType.PUBLIC_KEY
     ] = PublicKeyCredentialType.PUBLIC_KEY
-    transports: Optional[List[AuthenticatorTransport]]
+
+    @classmethod
+    def parse_raw(cls, json_str: str):
+        parsed: dict = json_loads_base64url_to_bytes(json_str)
+        parsed_response: dict = parsed["response"]
+        return cls(
+            id=parsed["id"],
+            raw_id=parsed["rawId"],
+            response=AuthenticatorAttestationResponse(
+                attestation_object=parsed_response.get("attestationObject"),
+                client_data_json=parsed_response.get("clientDataJSON"),
+            ),
+        )
 
 
-class AttestationStatement(BaseModel):
+@define
+class AttestationStatement:
     """A collection of all possible fields that may exist in an attestation statement. Combinations of these fields are specific to a particular attestation format.
 
     https://www.w3.org/TR/webauthn-2/#sctn-defined-attestation-formats
@@ -368,16 +375,17 @@ class AttestationStatement(BaseModel):
     attestation format.
     """
 
-    sig: Optional[bytes]
-    x5c: Optional[List[bytes]]
-    response: Optional[bytes]
-    alg: Optional[COSEAlgorithmIdentifier]
-    ver: Optional[str]
-    cert_info: Optional[bytes]
-    pub_area: Optional[bytes]
+    sig: Optional[bytes] = None
+    x5c: Optional[List[bytes]] = None
+    response: Optional[bytes] = None
+    alg: Optional[COSEAlgorithmIdentifier] = None
+    ver: Optional[str] = None
+    cert_info: Optional[bytes] = None
+    pub_area: Optional[bytes] = None
 
 
-class AuthenticatorDataFlags(BaseModel):
+@define
+class AuthenticatorDataFlags:
     """Flags the authenticator will set about information contained within the `attestationObject.authData` property.
 
     Attributes:
@@ -394,7 +402,8 @@ class AuthenticatorDataFlags(BaseModel):
     ed: bool
 
 
-class AttestedCredentialData(BaseModel):
+@define
+class AttestedCredentialData:
     """Information about a credential.
 
     Attributes:
@@ -410,7 +419,8 @@ class AttestedCredentialData(BaseModel):
     credential_public_key: bytes
 
 
-class AuthenticatorData(BaseModel):
+@define
+class AuthenticatorData:
     """Context the authenticator provides about itself and the environment in which the registration or authentication ceremony took place.
 
     Attributes:
@@ -427,11 +437,12 @@ class AuthenticatorData(BaseModel):
     rp_id_hash: bytes
     flags: AuthenticatorDataFlags
     sign_count: int
-    attested_credential_data: Optional[AttestedCredentialData]
-    extensions: Optional[bytes]
+    attested_credential_data: Optional[AttestedCredentialData] = None
+    extensions: Optional[bytes] = None
 
 
-class AttestationObject(BaseModel):
+@define
+class AttestationObject:
     """Information about an attestation, including a statement and authenticator data.
 
     Attributes:
@@ -443,8 +454,8 @@ class AttestationObject(BaseModel):
     """
 
     fmt: AttestationFormat
-    att_stmt: AttestationStatement = AttestationStatement()
     auth_data: AuthenticatorData
+    att_stmt: AttestationStatement = AttestationStatement()
 
 
 ################
@@ -454,7 +465,8 @@ class AttestationObject(BaseModel):
 ################
 
 
-class PublicKeyCredentialRequestOptions(WebAuthnBaseModel):
+@define
+class PublicKeyCredentialRequestOptions:
     """Authentication Options.
 
     Attributes:
@@ -468,15 +480,16 @@ class PublicKeyCredentialRequestOptions(WebAuthnBaseModel):
     """
 
     challenge: bytes
-    timeout: Optional[int]
-    rp_id: Optional[str]
+    timeout: Optional[int] = None
+    rp_id: Optional[str] = None
     allow_credentials: Optional[List[PublicKeyCredentialDescriptor]] = []
     user_verification: Optional[
         UserVerificationRequirement
     ] = UserVerificationRequirement.PREFERRED
 
 
-class AuthenticatorAssertionResponse(WebAuthnBaseModel):
+@define
+class AuthenticatorAssertionResponse:
     """The `response` property on an authentication credential.
 
     Attributes:
@@ -491,10 +504,11 @@ class AuthenticatorAssertionResponse(WebAuthnBaseModel):
     client_data_json: bytes
     authenticator_data: bytes
     signature: bytes
-    user_handle: Optional[bytes]
+    user_handle: Optional[bytes] = None
 
 
-class AuthenticationCredential(WebAuthnBaseModel):
+@define
+class AuthenticationCredential:
     """An authentication-specific subclass of PublicKeyCredential. Returned from `navigator.credentials.get()`
 
     Attributes:
@@ -512,3 +526,18 @@ class AuthenticationCredential(WebAuthnBaseModel):
     type: Literal[
         PublicKeyCredentialType.PUBLIC_KEY
     ] = PublicKeyCredentialType.PUBLIC_KEY
+
+    @classmethod
+    def parse_raw(cls, json_str: str):
+        parsed: dict = json_loads_base64url_to_bytes(json_str)
+        parsed_response: dict = parsed["response"]
+        return cls(
+            id=parsed["id"],
+            raw_id=parsed["rawId"],
+            response=AuthenticatorAssertionResponse(
+                client_data_json=parsed_response.get("clientDataJSON"),
+                authenticator_data=parsed_response.get("authenticatorData"),
+                signature=parsed_response.get("signature"),
+                user_handle=parsed_response.get("userHandle"),
+            ),
+        )

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -535,6 +535,6 @@ class AuthenticationCredential:
                 client_data_json=parsed_response["clientDataJSON"],
                 authenticator_data=parsed_response["authenticatorData"],
                 signature=parsed_response["signature"],
-                user_handle=parsed_response["userHandle"],
+                user_handle=parsed_response.get("userHandle"),
             ),
         )

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -2,7 +2,6 @@ from enum import Enum
 from typing import List, Literal, Optional, Union, Type
 import json
 
-import attr
 from attr import define
 
 from .bytes_to_base64url import bytes_to_base64url
@@ -232,9 +231,7 @@ class PublicKeyCredentialDescriptor:
     type: Literal[
         PublicKeyCredentialType.PUBLIC_KEY
     ] = PublicKeyCredentialType.PUBLIC_KEY
-    transports: Optional[List[AuthenticatorTransport]] = attr.field(
-        default=attr.Factory(list)
-    )
+    transports: Optional[List[AuthenticatorTransport]] = None
 
 
 @define
@@ -358,8 +355,8 @@ class RegistrationCredential:
             id=parsed["id"],
             raw_id=parsed["rawId"],
             response=AuthenticatorAttestationResponse(
-                attestation_object=parsed_response.get("attestationObject"),
-                client_data_json=parsed_response.get("clientDataJSON"),
+                attestation_object=parsed_response["attestationObject"],
+                client_data_json=parsed_response["clientDataJSON"],
             ),
         )
 
@@ -535,9 +532,9 @@ class AuthenticationCredential:
             id=parsed["id"],
             raw_id=parsed["rawId"],
             response=AuthenticatorAssertionResponse(
-                client_data_json=parsed_response.get("clientDataJSON"),
-                authenticator_data=parsed_response.get("authenticatorData"),
-                signature=parsed_response.get("signature"),
-                user_handle=parsed_response.get("userHandle"),
+                client_data_json=parsed_response["clientDataJSON"],
+                authenticator_data=parsed_response["authenticatorData"],
+                signature=parsed_response["signature"],
+                user_handle=parsed_response["userHandle"],
             ),
         )

--- a/webauthn/registration/formats/android_key.py
+++ b/webauthn/registration/formats/android_key.py
@@ -25,7 +25,10 @@ from webauthn.helpers.asn1.android_key import (
     KeyOrigin,
     KeyPurpose,
 )
-from webauthn.helpers.exceptions import InvalidCertificateChain, InvalidRegistrationResponse
+from webauthn.helpers.exceptions import (
+    InvalidCertificateChain,
+    InvalidRegistrationResponse,
+)
 from webauthn.helpers.known_root_certs import (
     google_hardware_attestation_root_1,
     google_hardware_attestation_root_2,

--- a/webauthn/registration/formats/android_key.py
+++ b/webauthn/registration/formats/android_key.py
@@ -85,12 +85,12 @@ def verify_android_key(
     # Generate a hash of client_data_json
     client_data_hash = hashlib.sha256()
     client_data_hash.update(client_data_json)
-    client_data_hash = client_data_hash.digest()
+    client_data_hash_bytes = client_data_hash.digest()
 
     verification_data = b"".join(
         [
             authenticator_data_bytes,
-            client_data_hash,
+            client_data_hash_bytes,
         ]
     )
 

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -1,7 +1,7 @@
 import base64
 import hashlib
 import json
-from typing import List
+from typing import List, Optional
 
 from attr import define
 import cbor2
@@ -37,8 +37,8 @@ class SafetyNetJWSHeader:
     def parse_raw(cls, header_data: str):
         parsed: dict = json_loads_base64url_to_bytes(base64url_to_bytes(header_data))
         return cls(
-            alg=parsed.get("alg"),
-            x5c=parsed.get("x5c"),
+            alg=parsed["alg"],
+            x5c=parsed["x5c"],
         )
 
 
@@ -62,13 +62,13 @@ class SafetyNetJWSPayload:
     def parse_raw(cls, payload_data: str):
         parsed: dict = json_loads_base64url_to_bytes(base64url_to_bytes(payload_data))
         return cls(
-            nonce=parsed.get("nonce"),
-            timestamp_ms=parsed.get("timestampMs"),
-            apk_package_name=parsed.get("apkPackageName"),
-            apk_digest_sha256=parsed.get("apkDigestSha256"),
-            cts_profile_match=parsed.get("ctsProfileMatch"),
-            apk_certificate_digest_sha256=parsed.get("apkCertificateDigestSha256"),
-            basic_integrity=parsed.get("basicIntegrity"),
+            nonce=parsed["nonce"],
+            timestamp_ms=parsed["timestampMs"],
+            apk_package_name=parsed["apkPackageName"],
+            apk_digest_sha256=parsed["apkDigestSha256"],
+            cts_profile_match=parsed["ctsProfileMatch"],
+            apk_certificate_digest_sha256=parsed["apkCertificateDigestSha256"],
+            basic_integrity=parsed["basicIntegrity"],
         )
 
 

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -115,7 +115,7 @@ def verify_android_safetynet(
 
     header = SafetyNetJWSHeader.parse_raw(jws_parts[0])
     payload = SafetyNetJWSPayload.parse_raw(jws_parts[1])
-    signature_bytes: str = jws_parts[2]
+    signature_bytes_str: str = jws_parts[2]
 
     # Verify that the nonce attribute in the payload of response is identical to the
     # Base64 encoding of the SHA-256 hash of the concatenation of authenticatorData and
@@ -128,24 +128,24 @@ def verify_android_safetynet(
     # Generate a hash of client_data_json
     client_data_hash = hashlib.sha256()
     client_data_hash.update(client_data_json)
-    client_data_hash = client_data_hash.digest()
+    client_data_hash_bytes = client_data_hash.digest()
 
     nonce_data = b"".join(
         [
             authenticator_data_bytes,
-            client_data_hash,
+            client_data_hash_bytes,
         ]
     )
     # Start with a sha256 hash
     nonce_data_hash = hashlib.sha256()
     nonce_data_hash.update(nonce_data)
-    nonce_data_hash = nonce_data_hash.digest()
+    nonce_data_hash_bytes = nonce_data_hash.digest()
     # Encode to base64
-    nonce_data_hash = base64.b64encode(nonce_data_hash)
+    nonce_data_hash_bytes = base64.b64encode(nonce_data_hash_bytes)
     # Finish by decoding to string
-    nonce_data_hash = nonce_data_hash.decode("utf-8")
+    nonce_data_str = nonce_data_hash_bytes.decode("utf-8")
 
-    if payload.nonce != nonce_data_hash:
+    if payload.nonce != nonce_data_str:
         raise InvalidRegistrationResponse(
             "Payload nonce was not expected value (SafetyNet)"
         )
@@ -192,7 +192,7 @@ def verify_android_safetynet(
 
     # Verify signature
     verification_data = f"{jws_parts[0]}.{jws_parts[1]}".encode("utf-8")
-    signature_bytes = base64url_to_bytes(signature_bytes)
+    signature_bytes = base64url_to_bytes(signature_bytes_str)
 
     if header.alg != "RS256":
         raise InvalidRegistrationResponse(

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -34,8 +34,8 @@ class SafetyNetJWSHeader:
     x5c: List[str]
 
     @classmethod
-    def parse_raw(cls, json_str: str):
-        parsed: dict = json_loads_base64url_to_bytes(json_str)
+    def parse_raw(cls, header_data: str):
+        parsed: dict = json_loads_base64url_to_bytes(base64url_to_bytes(header_data))
         return cls(
             alg=parsed.get("alg"),
             x5c=parsed.get("x5c"),
@@ -59,8 +59,8 @@ class SafetyNetJWSPayload:
     basic_integrity: bool
 
     @classmethod
-    def parse_raw(cls, json_str: str):
-        parsed: dict = json_loads_base64url_to_bytes(json_str)
+    def parse_raw(cls, payload_data: str):
+        parsed: dict = json_loads_base64url_to_bytes(base64url_to_bytes(payload_data))
         return cls(
             nonce=parsed.get("nonce"),
             timestamp_ms=parsed.get("timestampMs"),
@@ -113,8 +113,8 @@ def verify_android_safetynet(
             "Response JWS did not have three parts (SafetyNet)"
         )
 
-    header = SafetyNetJWSHeader.parse_raw(base64url_to_bytes(jws_parts[0]))
-    payload = SafetyNetJWSPayload.parse_raw(base64url_to_bytes(jws_parts[1]))
+    header = SafetyNetJWSHeader.parse_raw(jws_parts[0])
+    payload = SafetyNetJWSPayload.parse_raw(jws_parts[1])
     signature_bytes: str = jws_parts[2]
 
     # Verify that the nonce attribute in the payload of response is identical to the

--- a/webauthn/registration/formats/apple.py
+++ b/webauthn/registration/formats/apple.py
@@ -17,7 +17,10 @@ from webauthn.helpers import (
     decoded_public_key_to_cryptography,
     validate_certificate_chain,
 )
-from webauthn.helpers.exceptions import InvalidCertificateChain, InvalidRegistrationResponse
+from webauthn.helpers.exceptions import (
+    InvalidCertificateChain,
+    InvalidRegistrationResponse,
+)
 from webauthn.helpers.known_root_certs import apple_webauthn_root_ca
 from webauthn.helpers.structs import AttestationStatement
 

--- a/webauthn/registration/formats/apple.py
+++ b/webauthn/registration/formats/apple.py
@@ -60,19 +60,19 @@ def verify_apple(
 
     client_data_hash = hashlib.sha256()
     client_data_hash.update(client_data_json)
-    client_data_hash = client_data_hash.digest()
+    client_data_hash_bytes = client_data_hash.digest()
 
     nonce_to_hash = b"".join(
         [
             authenticator_data_bytes,
-            client_data_hash,
+            client_data_hash_bytes,
         ]
     )
 
     # Perform SHA-256 hash of nonceToHash to produce nonce.
     nonce = hashlib.sha256()
     nonce.update(nonce_to_hash)
-    nonce = nonce.digest()
+    nonce_bytes = nonce.digest()
 
     # Verify that nonce equals the value of the extension with
     # OID 1.2.840.113635.100.8.2 in credCert.
@@ -100,7 +100,7 @@ def verify_apple(
     # OCTET STRING. Should trim off '0$\xa1"\x04'
     ext_value: bytes = ext_value_wrapper.value[6:]
 
-    if ext_value != nonce:
+    if ext_value != nonce_bytes:
         raise InvalidRegistrationResponse(
             "Certificate nonce was not expected value (Apple)"
         )

--- a/webauthn/registration/formats/fido_u2f.py
+++ b/webauthn/registration/formats/fido_u2f.py
@@ -9,13 +9,20 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePublicKey,
 )
 
-from webauthn.helpers import aaguid_to_string, validate_certificate_chain, verify_signature
+from webauthn.helpers import (
+    aaguid_to_string,
+    validate_certificate_chain,
+    verify_signature,
+)
 from webauthn.helpers.cose import COSEAlgorithmIdentifier
 from webauthn.helpers.decode_credential_public_key import (
     DecodedEC2PublicKey,
     decode_credential_public_key,
 )
-from webauthn.helpers.exceptions import InvalidCertificateChain, InvalidRegistrationResponse
+from webauthn.helpers.exceptions import (
+    InvalidCertificateChain,
+    InvalidRegistrationResponse,
+)
 from webauthn.helpers.structs import AttestationStatement
 
 

--- a/webauthn/registration/formats/fido_u2f.py
+++ b/webauthn/registration/formats/fido_u2f.py
@@ -107,14 +107,14 @@ def verify_fido_u2f(
     # Generate a hash of client_data_json
     client_data_hash = hashlib.sha256()
     client_data_hash.update(client_data_json)
-    client_data_hash = client_data_hash.digest()
+    client_data_hash_bytes = client_data_hash.digest()
 
     # Prepare the signature base (called "verificationData" in the WebAuthn spec)
     verification_data = b"".join(
         [
             bytes([0x00]),
             rp_id_hash,
-            client_data_hash,
+            client_data_hash_bytes,
             credential_id,
             public_key_u2f,
         ]

--- a/webauthn/registration/formats/packed.py
+++ b/webauthn/registration/formats/packed.py
@@ -12,7 +12,10 @@ from webauthn.helpers import (
     validate_certificate_chain,
     verify_signature,
 )
-from webauthn.helpers.exceptions import InvalidCertificateChain, InvalidRegistrationResponse
+from webauthn.helpers.exceptions import (
+    InvalidCertificateChain,
+    InvalidRegistrationResponse,
+)
 from webauthn.helpers.structs import AttestationStatement
 
 

--- a/webauthn/registration/formats/packed.py
+++ b/webauthn/registration/formats/packed.py
@@ -48,12 +48,12 @@ def verify_packed(
     # Generate a hash of client_data_json
     client_data_hash = hashlib.sha256()
     client_data_hash.update(client_data_json)
-    client_data_hash = client_data_hash.digest()
+    client_data_hash_bytes = client_data_hash.digest()
 
     verification_data = b"".join(
         [
             authenticator_data_bytes,
-            client_data_hash,
+            client_data_hash_bytes,
         ]
     )
 

--- a/webauthn/registration/formats/tpm.py
+++ b/webauthn/registration/formats/tpm.py
@@ -24,7 +24,10 @@ from webauthn.helpers.decode_credential_public_key import (
     DecodedEC2PublicKey,
     DecodedRSAPublicKey,
 )
-from webauthn.helpers.exceptions import InvalidCertificateChain, InvalidRegistrationResponse
+from webauthn.helpers.exceptions import (
+    InvalidCertificateChain,
+    InvalidRegistrationResponse,
+)
 from webauthn.helpers.structs import AttestationStatement
 from webauthn.helpers.tpm import parse_cert_info, parse_pub_area
 from webauthn.helpers.tpm.structs import (

--- a/webauthn/registration/verify_registration_response.py
+++ b/webauthn/registration/verify_registration_response.py
@@ -1,6 +1,8 @@
 import hashlib
 from typing import List, Mapping, Optional, Union
 
+from attr import define, asdict
+
 from webauthn.helpers import (
     aaguid_to_string,
     bytes_to_base64url,
@@ -16,7 +18,6 @@ from webauthn.helpers.structs import (
     PublicKeyCredentialType,
     RegistrationCredential,
     TokenBindingStatus,
-    WebAuthnBaseModel,
 )
 from .formats.android_key import verify_android_key
 from .formats.android_safetynet import verify_android_safetynet
@@ -27,7 +28,8 @@ from .formats.tpm import verify_tpm
 from .generate_registration_options import default_supported_pub_key_algs
 
 
-class VerifiedRegistration(WebAuthnBaseModel):
+@define
+class VerifiedRegistration:
     """Information about a verified attestation of which an RP can make use.
 
     Attributes:
@@ -194,8 +196,12 @@ def verify_registration_response(
     if attestation_object.fmt == AttestationFormat.NONE:
         # A "none" attestation should not contain _anything_ in its attestation
         # statement
-        num_att_stmt_fields_set = len(attestation_object.att_stmt.__fields_set__)
-        if num_att_stmt_fields_set > 0:
+        num_att_stmt_fields_set = [
+            val
+            for _, val in asdict(attestation_object.att_stmt).items()
+            if val is not None
+        ]
+        if len(num_att_stmt_fields_set) > 0:
             raise InvalidRegistrationResponse(
                 "None attestation had unexpected attestation statement"
             )

--- a/webauthn/registration/verify_registration_response.py
+++ b/webauthn/registration/verify_registration_response.py
@@ -143,9 +143,9 @@ def verify_registration_response(
     # Generate a hash of the expected RP ID for comparison
     expected_rp_id_hash = hashlib.sha256()
     expected_rp_id_hash.update(expected_rp_id.encode("utf-8"))
-    expected_rp_id_hash = expected_rp_id_hash.digest()
+    expected_rp_id_hash_bytes = expected_rp_id_hash.digest()
 
-    if auth_data.rp_id_hash != expected_rp_id_hash:
+    if auth_data.rp_id_hash != expected_rp_id_hash_bytes:
         raise InvalidRegistrationResponse("Unexpected RP ID hash")
 
     if not auth_data.flags.up:


### PR DESCRIPTION
This PR Is an attempt to swap out **Pydantic** use for the **attrs**+**cattrs** library combo. Based on feedback in Issue #110 I've come around to the idea that this library should incorporate dependencies that won't impose "restrictions" on which other dependencies the actual application consuming this library can use.

For example: if a project wishing to use py_webauthn can't because their credential IDs and public keys are passed around as pymongo's `bytes` subclasses, and Pydantic won't accept these values because they're not `bytes`, then maybe the validation logic is a bit too restrictive. If the subclass otherwise handles like a raw `bytes` value why shouldn't it Just Work™?

The work to switch over to attrs was fairly simple. I figured I'd put it up here for feedback on whether or not I should make this change.