### PR TITLE
restore-pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 asn1crypto==1.4.0
-attrs==21.2.0
 black==21.9b0
-cattrs==1.8.0
 cbor2==5.4.2
 cffi==1.15.0
 click==8.0.3
@@ -13,6 +11,7 @@ pathspec==0.9.0
 platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
+pydantic==1.8.2
 pyflakes==2.4.0
 pyOpenSSL==21.0.0
 regex==2021.10.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pathspec==0.9.0
 platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
-pydantic==1.8.2
+pydantic==1.9.0
 pyflakes==2.4.0
 pyOpenSSL==21.0.0
 regex==2021.10.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 asn1crypto==1.4.0
 black==21.9b0
-cbor2==5.4.2
+cbor2==5.4.2.post1
 cffi==1.15.0
 click==8.0.3
-cryptography==3.4.8
+cryptography==36.0.1
 mccabe==0.6.1
 mypy==0.910
 mypy-extensions==0.4.3
@@ -13,7 +13,7 @@ pycodestyle==2.8.0
 pycparser==2.20
 pydantic==1.9.0
 pyflakes==2.4.0
-pyOpenSSL==21.0.0
+pyOpenSSL==22.0.0
 regex==2021.10.8
 six==1.16.0
 toml==0.10.2

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,7 @@ setup(
         'asn1crypto>=0.24.0',
         'cbor2>=4.0.1',
         'cryptography>=3.4.7',
-        'attrs>=21.2.0',
-        'cattrs>=1.8.0',
+        'pydantic>=1.8.2',
         'pyOpenSSL>=20.0.1',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Programming Language :: Python :: 3'
     ],
     install_requires=[
-        'asn1crypto>=0.24.0',
+        'asn1crypto>=1.4.0',
         'cbor2>=5.4.2.post1',
         'cryptography>=36.0.1',
         'pydantic>=1.9.0',

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ setup(
     ],
     install_requires=[
         'asn1crypto>=0.24.0',
-        'cbor2>=4.0.1',
-        'cryptography>=3.4.7',
+        'cbor2>=5.4.2.post1',
+        'cryptography>=36.0.1',
         'pydantic>=1.9.0',
-        'pyOpenSSL>=20.0.1',
+        'pyOpenSSL>=22.0.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'asn1crypto>=0.24.0',
         'cbor2>=4.0.1',
         'cryptography>=3.4.7',
-        'pydantic>=1.8.2',
+        'pydantic>=1.9.0',
         'pyOpenSSL>=20.0.1',
     ]
 )

--- a/tests/test_verify_registration_response.py
+++ b/tests/test_verify_registration_response.py
@@ -86,7 +86,7 @@ class TestVerifyRegistrationResponse(TestCase):
         expected_origin = "http://localhost:5000"
 
         with self.assertRaisesRegex(
-            Exception, "Unsupported attestation type"
+            Exception, "value is not a valid enumeration member"
         ):
             verify_registration_response(
                 credential=credential,

--- a/tests/test_verify_registration_response_fido_u2f.py
+++ b/tests/test_verify_registration_response_fido_u2f.py
@@ -90,15 +90,17 @@ class TestVerifyRegistrationResponseFIDOU2F(TestCase):
         rp_id = "duo.test"
         expected_origin = "https://api-duo1.duo.test"
 
-        with self.assertRaisesRegex(
-            Exception, "Unexpected token_binding status"
-        ):
-            verify_registration_response(
-                credential=credential,
-                expected_challenge=challenge,
-                expected_origin=expected_origin,
-                expected_rp_id=rp_id,
-            )
+        verification = verify_registration_response(
+            credential=credential,
+            expected_challenge=challenge,
+            expected_origin=expected_origin,
+            expected_rp_id=rp_id,
+        )
+
+        assert verification.fmt == AttestationFormat.FIDO_U2F
+        assert verification.credential_id == base64url_to_bytes(
+            "JeC3qgQjIVysq88GxhGUYyDl4oZeW8mLWd7luJWQvnrm-wxGZ5mzf2bBCaUDq7D2qr4aQezvzfoFIF880ciAsQ",
+        )
 
     def test_verify_attestation_with_unsupported_token_binding(self) -> None:
         # Credential contains `clientDataJSON: { tokenBinding: "unused" }`

--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -18,6 +18,7 @@ from webauthn.helpers.structs import (
     PublicKeyCredentialType,
     TokenBindingStatus,
     WebAuthnBaseModel,
+    BytesLike,
 )
 
 
@@ -26,7 +27,7 @@ class VerifiedAuthentication(WebAuthnBaseModel):
     Information about a verified authentication of which an RP can make use
     """
 
-    credential_id: bytes
+    credential_id: BytesLike
     new_sign_count: int
 
 

--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -1,7 +1,6 @@
 import hashlib
 from typing import List, Union
 
-from attr import define
 from cryptography.exceptions import InvalidSignature
 
 from webauthn.helpers import (
@@ -18,11 +17,11 @@ from webauthn.helpers.structs import (
     ClientDataType,
     PublicKeyCredentialType,
     TokenBindingStatus,
+    WebAuthnBaseModel,
 )
 
 
-@define
-class VerifiedAuthentication:
+class VerifiedAuthentication(WebAuthnBaseModel):
     """
     Information about a verified authentication of which an RP can make use
     """

--- a/webauthn/helpers/decode_credential_public_key.py
+++ b/webauthn/helpers/decode_credential_public_key.py
@@ -1,22 +1,20 @@
 from typing import Union
 
-from attr import define
 from cbor2 import decoder
+from pydantic import BaseModel
 
 from .cose import COSECRV, COSEKTY, COSEAlgorithmIdentifier, COSEKey
 from .exceptions import InvalidPublicKeyStructure, UnsupportedPublicKeyType
 
 
-@define
-class DecodedOKPPublicKey:
+class DecodedOKPPublicKey(BaseModel):
     kty: COSEKTY
     alg: COSEAlgorithmIdentifier
     crv: COSECRV
     x: bytes
 
 
-@define
-class DecodedEC2PublicKey:
+class DecodedEC2PublicKey(BaseModel):
     kty: COSEKTY
     alg: COSEAlgorithmIdentifier
     crv: COSECRV
@@ -24,8 +22,7 @@ class DecodedEC2PublicKey:
     y: bytes
 
 
-@define
-class DecodedRSAPublicKey:
+class DecodedRSAPublicKey(BaseModel):
     kty: COSEKTY
     alg: COSEAlgorithmIdentifier
     n: bytes

--- a/webauthn/helpers/options_to_json.py
+++ b/webauthn/helpers/options_to_json.py
@@ -1,9 +1,4 @@
-import json
 from typing import Union
-
-from attr import has, fields
-from cattr.preconf.json import make_converter
-from cattr.gen import make_dict_unstructure_fn, make_dict_structure_fn, override
 
 from .structs import (
     PublicKeyCredentialCreationOptions,
@@ -11,29 +6,6 @@ from .structs import (
 )
 from .snake_case_to_camel_case import snake_case_to_camel_case
 from .bytes_to_base64url import bytes_to_base64url
-
-
-# Create a converter to convert our attr classes into JSON strings
-converter = make_converter()
-# Convert snake_case property names to camelCase
-def _to_camel_case_unstructure(cls):
-    return make_dict_unstructure_fn(
-        cls,
-        converter,
-        **{
-            attribute.name: override(
-                # Avoid sending optional `None` defaults as `null` in JSON
-                omit_if_default=attribute.default is None,
-                rename=snake_case_to_camel_case(attribute.name),
-            )
-            for attribute in fields(cls)
-        }
-    )
-
-
-converter.register_unstructure_hook_factory(has, _to_camel_case_unstructure)
-# Encode bytes values to base64url
-converter.register_unstructure_hook(bytes, bytes_to_base64url)
 
 
 def options_to_json(
@@ -45,4 +17,8 @@ def options_to_json(
     """
     Prepare options for transmission to the front end as JSON
     """
-    return json.dumps(converter.unstructure(options))
+    return options.json(
+        by_alias=True,
+        exclude_unset=False,
+        exclude_none=True,
+    )

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -238,7 +238,7 @@ class PublicKeyCredentialUserEntity(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialuserentity
     """
 
-    id: bytes
+    id: BytesLike
     name: str
     display_name: str
 
@@ -268,7 +268,7 @@ class PublicKeyCredentialDescriptor(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialdescriptor
     """
 
-    id: bytes
+    id: BytesLike
     type: Literal[
         PublicKeyCredentialType.PUBLIC_KEY
     ] = PublicKeyCredentialType.PUBLIC_KEY
@@ -309,7 +309,7 @@ class CollectedClientData(WebAuthnBaseModel):
     """
 
     type: ClientDataType
-    challenge: bytes
+    challenge: BytesLike
     origin: str
     cross_origin: Optional[bool] = None
     token_binding: Optional[TokenBinding] = None
@@ -340,7 +340,7 @@ class PublicKeyCredentialCreationOptions(WebAuthnBaseModel):
 
     rp: PublicKeyCredentialRpEntity
     user: PublicKeyCredentialUserEntity
-    challenge: bytes
+    challenge: BytesLike
     pub_key_cred_params: List[PublicKeyCredentialParameters]
     timeout: Optional[int] = None
     exclude_credentials: Optional[List[PublicKeyCredentialDescriptor]] = None
@@ -358,8 +358,8 @@ class AuthenticatorAttestationResponse(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#authenticatorattestationresponse
     """
 
-    client_data_json: bytes
-    attestation_object: bytes
+    client_data_json: BytesLike
+    attestation_object: BytesLike
 
 
 class RegistrationCredential(WebAuthnBaseModel):
@@ -376,7 +376,7 @@ class RegistrationCredential(WebAuthnBaseModel):
     """
 
     id: str
-    raw_id: bytes
+    raw_id: BytesLike
     response: AuthenticatorAttestationResponse
     transports: Optional[List[AuthenticatorTransport]] = None
     type: Literal[
@@ -431,9 +431,9 @@ class AttestedCredentialData(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#attested-credential-data
     """
 
-    aaguid: bytes
-    credential_id: bytes
-    credential_public_key: bytes
+    aaguid: BytesLike
+    credential_id: BytesLike
+    credential_public_key: BytesLike
 
 
 class AuthenticatorData(WebAuthnBaseModel):
@@ -450,7 +450,7 @@ class AuthenticatorData(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#sctn-attested-credential-data
     """
 
-    rp_id_hash: bytes
+    rp_id_hash: BytesLike
     flags: AuthenticatorDataFlags
     sign_count: int
     attested_credential_data: Optional[AttestedCredentialData] = None
@@ -493,7 +493,7 @@ class PublicKeyCredentialRequestOptions(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options
     """
 
-    challenge: bytes
+    challenge: BytesLike
     timeout: Optional[int] = None
     rp_id: Optional[str] = None
     allow_credentials: Optional[List[PublicKeyCredentialDescriptor]] = []
@@ -514,9 +514,9 @@ class AuthenticatorAssertionResponse(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#authenticatorassertionresponse
     """
 
-    client_data_json: bytes
-    authenticator_data: bytes
-    signature: bytes
+    client_data_json: BytesLike
+    authenticator_data: BytesLike
+    signature: BytesLike
     user_handle: Optional[bytes] = None
 
 
@@ -533,7 +533,7 @@ class AuthenticationCredential(WebAuthnBaseModel):
     """
 
     id: str
-    raw_id: bytes
+    raw_id: BytesLike
     response: AuthenticatorAssertionResponse
     type: Literal[
         PublicKeyCredentialType.PUBLIC_KEY

--- a/webauthn/helpers/verify_signature.py
+++ b/webauthn/helpers/verify_signature.py
@@ -4,6 +4,8 @@ from cryptography.hazmat.primitives.asymmetric.dsa import DSAPublicKey
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PublicKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PublicKey
+from cryptography.hazmat.primitives.asymmetric.x448 import X448PublicKey
 from cryptography.hazmat.primitives.asymmetric.padding import MGF1, PSS, PKCS1v15
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
@@ -26,6 +28,8 @@ def verify_signature(
         Ed25519PublicKey,
         DSAPublicKey,
         Ed448PublicKey,
+        X25519PublicKey,
+        X448PublicKey,
     ],
     signature_alg: COSEAlgorithmIdentifier,
     signature: bytes,

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -1,9 +1,7 @@
 import base64
 import hashlib
-import json
-from typing import List, Optional
+from typing import List
 
-from attr import define
 import cbor2
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
@@ -16,34 +14,23 @@ from webauthn.helpers import (
     validate_certificate_chain,
     verify_safetynet_timestamp,
     verify_signature,
-    json_loads_base64url_to_bytes,
 )
 from webauthn.helpers.exceptions import (
     InvalidCertificateChain,
     InvalidRegistrationResponse,
 )
 from webauthn.helpers.known_root_certs import globalsign_r2, globalsign_root_ca
-from webauthn.helpers.structs import AttestationStatement
+from webauthn.helpers.structs import AttestationStatement, WebAuthnBaseModel
 
 
-@define
-class SafetyNetJWSHeader:
+class SafetyNetJWSHeader(WebAuthnBaseModel):
     """Properties in the Header of a SafetyNet JWS"""
 
     alg: str
     x5c: List[str]
 
-    @classmethod
-    def parse_raw(cls, header_data: str):
-        parsed: dict = json_loads_base64url_to_bytes(base64url_to_bytes(header_data))
-        return cls(
-            alg=parsed["alg"],
-            x5c=parsed["x5c"],
-        )
 
-
-@define
-class SafetyNetJWSPayload:
+class SafetyNetJWSPayload(WebAuthnBaseModel):
     """Properties in the Payload of a SafetyNet JWS
 
     Values below correspond to camelCased properties in the JWS itself. This class
@@ -57,19 +44,6 @@ class SafetyNetJWSPayload:
     cts_profile_match: bool
     apk_certificate_digest_sha256: List[str]
     basic_integrity: bool
-
-    @classmethod
-    def parse_raw(cls, payload_data: str):
-        parsed: dict = json_loads_base64url_to_bytes(base64url_to_bytes(payload_data))
-        return cls(
-            nonce=parsed["nonce"],
-            timestamp_ms=parsed["timestampMs"],
-            apk_package_name=parsed["apkPackageName"],
-            apk_digest_sha256=parsed["apkDigestSha256"],
-            cts_profile_match=parsed["ctsProfileMatch"],
-            apk_certificate_digest_sha256=parsed["apkCertificateDigestSha256"],
-            basic_integrity=parsed["basicIntegrity"],
-        )
 
 
 def verify_android_safetynet(

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -87,8 +87,8 @@ def verify_android_safetynet(
             "Response JWS did not have three parts (SafetyNet)"
         )
 
-    header = SafetyNetJWSHeader.parse_raw(jws_parts[0])
-    payload = SafetyNetJWSPayload.parse_raw(jws_parts[1])
+    header = SafetyNetJWSHeader.parse_raw(base64url_to_bytes(jws_parts[0]))
+    payload = SafetyNetJWSPayload.parse_raw(base64url_to_bytes(jws_parts[1]))
     signature_bytes_str: str = jws_parts[2]
 
     # Verify that the nonce attribute in the payload of response is identical to the

--- a/webauthn/registration/formats/tpm.py
+++ b/webauthn/registration/formats/tpm.py
@@ -10,6 +10,7 @@ from cryptography.x509 import (
     Name,
     SubjectAlternativeName,
     Version,
+    BasicConstraints,
 )
 from cryptography.x509.extensions import ExtensionNotFound
 from cryptography.x509.oid import ExtensionOID
@@ -232,17 +233,17 @@ def verify_tpm(
     # The Subject Alternative Name extension MUST be set as defined in
     # [TPMv2-EK-Profile] section 3.2.9.
     try:
+        # Ignore mypy because we're casting to a known type
         ext_subject_alt_name: SubjectAlternativeName = (
-            cert_extensions.get_extension_for_oid(
-                ExtensionOID.SUBJECT_ALTERNATIVE_NAME
-            ).value
+            cert_extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME).value  # type: ignore[assignment]
         )
     except ExtensionNotFound:
         raise InvalidRegistrationResponse(
             f"Certificate missing extension {ExtensionOID.SUBJECT_ALTERNATIVE_NAME} (TPM)"
         )
 
-    tcg_at_tpm_values: Name = ext_subject_alt_name.get_values_for_type(GeneralName)[0]
+    # `type(tcg_at_tpm_values)` return "<class 'cryptography.x509.name.Name'>" so ignore mypy
+    tcg_at_tpm_values: Name = ext_subject_alt_name.get_values_for_type(GeneralName)[0]  # type: ignore[arg-type, assignment]
     tcg_at_tpm_manufacturer = None
     tcg_at_tpm_model = None
     tcg_at_tpm_version = None
@@ -271,8 +272,9 @@ def verify_tpm(
     # ("joint-iso-itu-t(2) internationalorganizations(23) 133 tcg-kp(8)
     # tcg-kp-AIKCertificate(3)").
     try:
+        # Ignore mypy because we're casting to a known type
         ext_extended_key_usage: ExtendedKeyUsage = (
-            cert_extensions.get_extension_for_oid(ExtensionOID.EXTENDED_KEY_USAGE).value
+            cert_extensions.get_extension_for_oid(ExtensionOID.EXTENDED_KEY_USAGE).value  # type: ignore[assignment]
         )
     except ExtensionNotFound:
         raise InvalidRegistrationResponse(
@@ -286,17 +288,18 @@ def verify_tpm(
             f'Certificate Extended Key Usage OID "{ext_key_usage_oid}" was not "2.23.133.8.3" (TPM)'
         )
 
-    # The Basic Constraints extension MUST have the CA component set to false.
     try:
-        ext_basic_constraints = cert_extensions.get_extension_for_oid(
+        # Ignore mypy because we're casting to a known type
+        ext_basic_constraints: BasicConstraints = cert_extensions.get_extension_for_oid(
             ExtensionOID.BASIC_CONSTRAINTS
-        )
+        ).value  # type: ignore[assignment]
     except ExtensionNotFound:
         raise InvalidRegistrationResponse(
             f"Certificate missing extension {ExtensionOID.BASIC_CONSTRAINTS} (TPM)"
         )
 
-    if ext_basic_constraints.value.ca is not False:
+    # The Basic Constraints extension MUST have the CA component set to false.
+    if ext_basic_constraints.ca is not False:
         raise InvalidRegistrationResponse(
             "Certificate Basic Constraints CA was not False (TPM)"
         )

--- a/webauthn/registration/verify_registration_response.py
+++ b/webauthn/registration/verify_registration_response.py
@@ -1,8 +1,6 @@
 import hashlib
 from typing import List, Mapping, Optional, Union
 
-from attr import define, asdict
-
 from webauthn.helpers import (
     aaguid_to_string,
     bytes_to_base64url,
@@ -18,6 +16,7 @@ from webauthn.helpers.structs import (
     PublicKeyCredentialType,
     RegistrationCredential,
     TokenBindingStatus,
+    WebAuthnBaseModel,
 )
 from .formats.android_key import verify_android_key
 from .formats.android_safetynet import verify_android_safetynet
@@ -28,8 +27,7 @@ from .formats.tpm import verify_tpm
 from .generate_registration_options import default_supported_pub_key_algs
 
 
-@define
-class VerifiedRegistration:
+class VerifiedRegistration(WebAuthnBaseModel):
     """Information about a verified attestation of which an RP can make use.
 
     Attributes:
@@ -196,12 +194,8 @@ def verify_registration_response(
     if attestation_object.fmt == AttestationFormat.NONE:
         # A "none" attestation should not contain _anything_ in its attestation
         # statement
-        num_att_stmt_fields_set = [
-            val
-            for _, val in asdict(attestation_object.att_stmt).items()
-            if val is not None
-        ]
-        if len(num_att_stmt_fields_set) > 0:
+        num_att_stmt_fields_set = len(attestation_object.att_stmt.__fields_set__)
+        if num_att_stmt_fields_set > 0:
             raise InvalidRegistrationResponse(
                 "None attestation had unexpected attestation statement"
             )

--- a/webauthn/registration/verify_registration_response.py
+++ b/webauthn/registration/verify_registration_response.py
@@ -17,6 +17,7 @@ from webauthn.helpers.structs import (
     RegistrationCredential,
     TokenBindingStatus,
     WebAuthnBaseModel,
+    BytesLike,
 )
 from .formats.android_key import verify_android_key
 from .formats.android_safetynet import verify_android_safetynet
@@ -41,14 +42,14 @@ class VerifiedRegistration(WebAuthnBaseModel):
         `attestation_object`: The raw attestation object for later scrutiny
     """
 
-    credential_id: bytes
-    credential_public_key: bytes
+    credential_id: BytesLike
+    credential_public_key: BytesLike
     sign_count: int
     aaguid: str
     fmt: AttestationFormat
     credential_type: PublicKeyCredentialType
     user_verified: bool
-    attestation_object: bytes
+    attestation_object: BytesLike
 
 
 expected_token_binding_statuses = [


### PR DESCRIPTION
After extensive conversation in #113 [I decided to revert all of the attrs+cattrs work](https://github.com/duo-labs/py_webauthn/issues/113#issuecomment-1018819410) made in PR #111. This PR restores use of Pydantic, and introduces a new custom bytes subclass that enables support for bytes-like values to prevent a regression of the fix for #110. There should be no change in API functionality.

I also updated all dependencies to the latest available versions.