### PR TITLE
fix/parse-auth-data-extension-data

### DIFF
--- a/webauthn/helpers/parse_authenticator_data.py
+++ b/webauthn/helpers/parse_authenticator_data.py
@@ -67,4 +67,10 @@ def parse_authenticator_data(val: bytes) -> AuthenticatorData:
         )
         authenticator_data.attested_credential_data = attested_cred_data
 
+    if flags.ed is True:
+        extension_object = cbor2.loads(val[pointer:])
+        extension_bytes = cbor2.dumps(extension_object)
+        pointer += len(extension_bytes)
+        authenticator_data.extensions = extension_bytes
+
     return authenticator_data

--- a/webauthn/helpers/parse_authenticator_data.py
+++ b/webauthn/helpers/parse_authenticator_data.py
@@ -73,4 +73,10 @@ def parse_authenticator_data(val: bytes) -> AuthenticatorData:
         pointer += len(extension_bytes)
         authenticator_data.extensions = extension_bytes
 
+    # We should have parsed all authenticator data by this point
+    if (len(val) > pointer):
+        raise InvalidAuthenticatorDataStructure(
+            "Leftover bytes detected while parsing authenticator data"
+        )
+
     return authenticator_data

--- a/webauthn/helpers/parse_authenticator_data.py
+++ b/webauthn/helpers/parse_authenticator_data.py
@@ -1,3 +1,5 @@
+import cbor2
+
 from .exceptions import InvalidAuthenticatorDataStructure
 from .structs import AttestedCredentialData, AuthenticatorData, AuthenticatorDataFlags
 
@@ -53,13 +55,15 @@ def parse_authenticator_data(val: bytes) -> AuthenticatorData:
         credential_id = val[pointer : pointer + credential_id_len]
         pointer += credential_id_len
 
-        # The remainder of the bytes will be the credential public key
-        credential_public_key = val[pointer:]
+        # Load the next CBOR-encoded value
+        credential_public_key = cbor2.loads(val[pointer:])
+        credential_public_key_bytes = cbor2.dumps(credential_public_key)
+        pointer += len(credential_public_key_bytes)
 
         attested_cred_data = AttestedCredentialData(
             aaguid=aaguid,
             credential_id=credential_id,
-            credential_public_key=credential_public_key,
+            credential_public_key=credential_public_key_bytes,
         )
         authenticator_data.attested_credential_data = attested_cred_data
 


### PR DESCRIPTION
Issue #124 highlighted how the library incorrectly parses a response's `authenticatorData`. For example, data containing extension data would return a malformed credential public key containing the extension data.

This diff enhances authenticator data parsing to always correctly return the credential public key, and also return the CBOR-encoded bytes structure representing any included extension data.

> NOTE: Parsing extension data into something intelligible will come later when I get around to addressing Issue #104. For now if you want the extension data in `authenticatorData` (instead of what is returned from [`getclientextensionresults()`](https://www.w3.org/TR/webauthn-2/#dom-publickeycredential-getclientextensionresults) in the browser) you can do something like this:

```python
import cbor2
from webauthn.helpers import parse_authenticator_data
from webauthn.helpers.structs import RegistrationCredential  # Should work for AuthenticationCredential too

credential = RegistrationCredential.parse_raw(credential_json)
parsed_auth_data = parse_authenticator_data(credential.response.authenticator_data)
parsed_extension_data: dict = cbor2.loads(parsed_auth_data.extensions)
```