### PR TITLE
Add credential protection policy and large blob support

### DIFF
--- a/webauthn/authentication/generate_authentication_options.py
+++ b/webauthn/authentication/generate_authentication_options.py
@@ -2,11 +2,11 @@ from typing import List, Optional
 
 from webauthn.helpers import generate_challenge
 from webauthn.helpers.structs import (
+    AuthenticationExtensionClientInputs,
+    AuthenticationExtensionsLargeBlobInputs,
     PublicKeyCredentialDescriptor,
     PublicKeyCredentialRequestOptions,
     UserVerificationRequirement,
-    AuthenticationExtensionsLargeBlobInputs,
-    AuthenticationExtensionClientInputs,
 )
 
 

--- a/webauthn/authentication/generate_authentication_options.py
+++ b/webauthn/authentication/generate_authentication_options.py
@@ -5,6 +5,8 @@ from webauthn.helpers.structs import (
     PublicKeyCredentialDescriptor,
     PublicKeyCredentialRequestOptions,
     UserVerificationRequirement,
+    AuthenticationExtensionsLargeBlobInputs,
+    AuthenticationExtensionClientInputs,
 )
 
 
@@ -15,6 +17,7 @@ def generate_authentication_options(
     timeout: int = 60000,
     allow_credentials: Optional[List[PublicKeyCredentialDescriptor]] = None,
     user_verification: UserVerificationRequirement = UserVerificationRequirement.PREFERRED,
+    large_blob_extension: Optional[AuthenticationExtensionsLargeBlobInputs] = None
 ) -> PublicKeyCredentialRequestOptions:
     """Generate options for retrieving a credential via navigator.credentials.get()
 
@@ -24,6 +27,7 @@ def generate_authentication_options(
         (optional) `timeout`: How long in milliseconds the browser should give the user to choose an authenticator. This value is a *hint* and may be ignored by the browser.
         (optional) `allow_credentials`: A list of credentials registered to the user.
         (optional) `user_verification`: The RP's preference for the authenticator's enforcement of the "user verified" flag.
+        (optional) `large_blob_extension`: The input for the large blob extension
 
     Returns:
         Authentication options ready for the browser. Consider using `helpers.options_to_json()` in this library to quickly convert the options to JSON.
@@ -39,10 +43,21 @@ def generate_authentication_options(
     if not allow_credentials:
         allow_credentials = []
 
-    return PublicKeyCredentialRequestOptions(
+    options = PublicKeyCredentialRequestOptions(
         rp_id=rp_id,
         challenge=challenge,
         timeout=timeout,
         allow_credentials=allow_credentials,
         user_verification=user_verification,
     )
+
+    ########
+    # Set optional values if specified
+    ########
+
+    if large_blob_extension is not None:
+        options.extensions = AuthenticationExtensionClientInputs(
+            large_blob=large_blob_extension
+        )
+
+    return options

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -297,7 +297,6 @@ class AuthenticatorSelectionCriteria(WebAuthnBaseModel):
         UserVerificationRequirement
     ] = UserVerificationRequirement.PREFERRED
 
-
 class CollectedClientData(WebAuthnBaseModel):
     """Decoded ClientDataJSON
 
@@ -349,6 +348,7 @@ class PublicKeyCredentialCreationOptions(WebAuthnBaseModel):
     exclude_credentials: Optional[List[PublicKeyCredentialDescriptor]] = None
     authenticator_selection: Optional[AuthenticatorSelectionCriteria] = None
     attestation: AttestationConveyancePreference = AttestationConveyancePreference.NONE
+    extensions: Optional[AuthenticationExtensionClientInputs] = None
 
 
 class AuthenticatorAttestationResponse(WebAuthnBaseModel):
@@ -475,6 +475,38 @@ class AttestationObject(WebAuthnBaseModel):
     auth_data: AuthenticatorData
     att_stmt: AttestationStatement = AttestationStatement()
 
+class LargeBlobSupport(str, Enum):
+    """A Relying Party's requirement for large blob support.
+
+    Members:
+        `REQUIRED`: Large blob support is required.
+        `PREFERRED`: Large blob support is preferred, but operation will not fail if the authenticator does not support large blobs.
+
+    https://www.w3.org/TR/webauthn-2/#enumdef-largeblobsupport
+    """
+
+    REQUIRED = "required"
+    PREFERRED = "preferred"
+
+# See https://www.w3.org/TR/webauthn-2/#sctn-large-blob-extension
+class AuthenticationExtensionsLargeBlobInputs(WebAuthnBaseModel):
+    """A Relying Party's input for the large blob extension.
+
+    Attributes:
+        (optional) `support`: Whether large blob support is requested
+        (optional) `read`: Whether the large blob content shall be read from the authenticator
+        (optional) `write`: The data that shall be written to the authenticator
+
+    https://www.w3.org/TR/webauthn-2/#dictdef-authenticationextensionslargeblobinputs
+    """
+    support: Optional[LargeBlobSupport] = None
+    read: Optional[bool] = None
+    write: Optional[bytes] = None
+
+class AuthenticationExtensionClientInputs(WebAuthnBaseModel):
+    # See https://www.w3.org/TR/webauthn-2/#sctn-large-blob-extension
+    large_blob: Optional[AuthenticationExtensionsLargeBlobInputs] = None
+
 
 ################
 #
@@ -503,6 +535,7 @@ class PublicKeyCredentialRequestOptions(WebAuthnBaseModel):
     user_verification: Optional[
         UserVerificationRequirement
     ] = UserVerificationRequirement.PREFERRED
+    extensions: Optional[AuthenticationExtensionClientInputs] = None
 
 
 class AuthenticatorAssertionResponse(WebAuthnBaseModel):

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -316,7 +316,6 @@ class CollectedClientData(WebAuthnBaseModel):
     cross_origin: Optional[bool] = None
     token_binding: Optional[TokenBinding] = None
 
-
 ################
 #
 # Registration
@@ -506,6 +505,20 @@ class AuthenticationExtensionsLargeBlobInputs(WebAuthnBaseModel):
 class AuthenticationExtensionClientInputs(WebAuthnBaseModel):
     # See https://www.w3.org/TR/webauthn-2/#sctn-large-blob-extension
     large_blob: Optional[AuthenticationExtensionsLargeBlobInputs] = None
+
+class CredentialProtectionPolicy(str, Enum):
+    """Various registered values indicating whether a credential shall be protected (influences how discoverable credentials are handled).
+
+    Members:
+        `USER_VERIFICATION_OPTIONAL`
+        `USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST`
+        `USER_VERIFICATION_REQUIRED`
+
+    https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credProtect-extension
+    """
+    USER_VERIFICATION_OPTIONAL = 'userVerificationOptional'
+    USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST = 'userVerificationOptionalWithCredentialIDList'
+    USER_VERIFICATION_REQUIRED = 'userVerificationRequired'
 
 
 ################

--- a/webauthn/registration/generate_registration_options.py
+++ b/webauthn/registration/generate_registration_options.py
@@ -7,6 +7,7 @@ from webauthn.helpers.structs import (
     AuthenticationExtensionClientInputs,
     AuthenticationExtensionsLargeBlobInputs,
     AuthenticatorSelectionCriteria,
+    CredentialProtectionPolicy,
     PublicKeyCredentialCreationOptions,
     PublicKeyCredentialDescriptor,
     PublicKeyCredentialParameters,
@@ -58,6 +59,8 @@ def generate_registration_options(
     exclude_credentials: Optional[List[PublicKeyCredentialDescriptor]] = None,
     supported_pub_key_algs: Optional[List[COSEAlgorithmIdentifier]] = None,
     large_blob_extension: Optional[AuthenticationExtensionsLargeBlobInputs] = None,
+    credential_protection_policy: Optional[CredentialProtectionPolicy] = None,
+    enforce_credential_protection_policy: Optional[bool] = None
 ) -> PublicKeyCredentialCreationOptions:
     """Generate options for registering a credential via navigator.credentials.create()
 
@@ -74,6 +77,8 @@ def generate_registration_options(
         (optional) `exclude_credentials`: A list of credentials the user has previously registered so that they cannot re-register them.
         (optional) `supported_pub_key_algs`: A list of public key algorithm IDs the RP chooses to restrict support to. Defaults to all supported algorithm IDs.
         (optional) `large_blob_extension`: Settings for large blobs.
+        (optional) `credential_protection_policy`: How (discoverable) credentials shall be protected.
+        (optional) `enforce_credential_protection_policy`: Abort if authenticator does not support credential the given protection policy.
 
     Returns:
         Registration options ready for the browser. Consider using `helpers.options_to_json()` in this library to quickly convert the options to JSON.
@@ -130,9 +135,10 @@ def generate_registration_options(
             authenticator_selection.require_resident_key = True
         options.authenticator_selection = authenticator_selection
 
-    if large_blob_extension:
-        options.extensions = AuthenticationExtensionClientInputs(
-            large_blob=large_blob_extension,
-        )
+    options.extensions = AuthenticationExtensionClientInputs(
+        large_blob=large_blob_extension,
+        credential_protection_policy=credential_protection_policy,
+        enforce_credential_protection_policy=enforce_credential_protection_policy,
+    )
 
     return options

--- a/webauthn/registration/generate_registration_options.py
+++ b/webauthn/registration/generate_registration_options.py
@@ -4,6 +4,8 @@ from webauthn.helpers import generate_challenge
 from webauthn.helpers.cose import COSEAlgorithmIdentifier
 from webauthn.helpers.structs import (
     AttestationConveyancePreference,
+    AuthenticationExtensionClientInputs,
+    AuthenticationExtensionsLargeBlobInputs,
     AuthenticatorSelectionCriteria,
     PublicKeyCredentialCreationOptions,
     PublicKeyCredentialDescriptor,
@@ -55,6 +57,7 @@ def generate_registration_options(
     authenticator_selection: Optional[AuthenticatorSelectionCriteria] = None,
     exclude_credentials: Optional[List[PublicKeyCredentialDescriptor]] = None,
     supported_pub_key_algs: Optional[List[COSEAlgorithmIdentifier]] = None,
+    large_blob_extension: Optional[AuthenticationExtensionsLargeBlobInputs] = None,
 ) -> PublicKeyCredentialCreationOptions:
     """Generate options for registering a credential via navigator.credentials.create()
 
@@ -70,6 +73,7 @@ def generate_registration_options(
         (optional) `authenticator_selection`: Require certain characteristics about an authenticator, like attachment, support for resident keys, user verification, etc...
         (optional) `exclude_credentials`: A list of credentials the user has previously registered so that they cannot re-register them.
         (optional) `supported_pub_key_algs`: A list of public key algorithm IDs the RP chooses to restrict support to. Defaults to all supported algorithm IDs.
+        (optional) `large_blob_extension`: Settings for large blobs.
 
     Returns:
         Registration options ready for the browser. Consider using `helpers.options_to_json()` in this library to quickly convert the options to JSON.
@@ -125,5 +129,10 @@ def generate_registration_options(
         if authenticator_selection.resident_key == ResidentKeyRequirement.REQUIRED:
             authenticator_selection.require_resident_key = True
         options.authenticator_selection = authenticator_selection
+
+    if large_blob_extension:
+        options.extensions = AuthenticationExtensionClientInputs(
+            large_blob=large_blob_extension,
+        )
 
     return options


### PR DESCRIPTION
We needed support for large blobs and credential protection policy in our project, which py_webauthn didn't provide. We added the appropriate structs and options to genereate_registration_options which worked fine for us. 

closes #127 