### PR TITLE
feat/cable-support

### DIFF
--- a/tests/test_verify_registration_response.py
+++ b/tests/test_verify_registration_response.py
@@ -166,3 +166,35 @@ class TestVerifyRegistrationResponse(TestCase):
                     AttestationFormat.PACKED: [globalsign_r2]
                 },
             )
+
+    def test_verifies_registration_over_cable(self) -> None:
+        credential = RegistrationCredential.parse_raw(
+            """{
+            "id": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
+            "rawId": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
+            "response": {
+                "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjESZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NFAAAAFwAAAAAAAAAAAAAAAAAAAAAAQPctcQPE5oNRRJk_nO_371mf7qE7qIodzr0eOf6ACvnMB1oQG165dqutoi1U44shGezu5_gkTjmOPeJO0N8a7P-lAQIDJiABIVggSFbUJF-42Ug3pdM8rDRFu_N5oiVEysPDB6n66r_7dZAiWCDUVnB39FlGypL-qAoIO9xWHtJygo2jfDmHl-_eKFRLDA",
+                "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiVHdON240V1R5R0tMYzRaWS1xR3NGcUtuSE00bmdscXN5VjBJQ0psTjJUTzlYaVJ5RnRya2FEd1V2c3FsLWdrTEpYUDZmbkYxTWxyWjUzTW00UjdDdnciLCJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjUwMDAiLCJjcm9zc09yaWdpbiI6ZmFsc2V9"
+            },
+            "type": "public-key",
+            "clientExtensionResults": {},
+            "transports": [
+                "cable"
+            ]
+        }"""
+        )
+
+        challenge = base64url_to_bytes(
+            "TwN7n4WTyGKLc4ZY-qGsFqKnHM4nglqsyV0ICJlN2TO9XiRyFtrkaDwUvsql-gkLJXP6fnF1MlrZ53Mm4R7Cvw"
+        )
+        rp_id = "localhost"
+        expected_origin = "http://localhost:5000"
+
+        verification = verify_registration_response(
+            credential=credential,
+            expected_challenge=challenge,
+            expected_origin=expected_origin,
+            expected_rp_id=rp_id,
+        )
+
+        assert verification.fmt == AttestationFormat.NONE

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -223,7 +223,7 @@ class PublicKeyCredentialRpEntity(WebAuthnBaseModel):
 
     Attributes:
         `name`: A user-readable name for the Relying Party
-        `id`: A unique, constant value assigned to the Relying Party. Authenticators use this value to associate a credential with a particular Relying Party user
+        (optional) `id`: A unique, constant value assigned to the Relying Party. Authenticators use this value to associate a credential with a particular Relying Party user
 
     https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialrpentity
     """
@@ -375,7 +375,7 @@ class RegistrationCredential(WebAuthnBaseModel):
         `raw_id`: A byte sequence representing the credential's unique identifier
         `response`: The authenticator's attesation data
         `type`: The literal string `"public-key"`
-        `transports`: The authenticator's supported methods of communication with a client/browser
+        (optional) `transports`: The authenticator's supported methods of communication with a client/browser
 
     https://www.w3.org/TR/webauthn-2/#publickeycredential
     """

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -74,6 +74,7 @@ class AuthenticatorTransport(str, Enum):
         `NFC`: Near Field Communication
         `BLE`: Bluetooth Low Energy
         `INTERNAL`: Direct connection (read: a platform authenticator)
+        `CABLE`: Cloud Assisted Bluetooth Low Energy
 
     https://www.w3.org/TR/webauthn-2/#enum-transport
     """
@@ -82,6 +83,7 @@ class AuthenticatorTransport(str, Enum):
     NFC = "nfc"
     BLE = "ble"
     INTERNAL = "internal"
+    CABLE = "cable"
 
 
 class AuthenticatorAttachment(str, Enum):


### PR DESCRIPTION
The `"cable"` transport hasn't formally been recognized in the WebAuthn spec yet, but that hasn't stopped Apple and Google from debuting support for this new means of performing WebAuthn registration and authentication ceremonies.

Since support is out in the wild as of Safari 15.4 and Chrome 100 I'm making an exception and adding support for this new value now. This should resolve errors like this that RP's might have started seeing:

```
pydantic.error_wrappers.ValidationError: 1 validation error for RegistrationCredential
transports -> 0
  value is not a valid enumeration member; permitted: 'usb', 'nfc', 'ble', 'internal'
  (type=type_error.enum; enum_values=[<AuthenticatorTransport.USB: 'usb'>,
  <AuthenticatorTransport.NFC: 'nfc'>, <AuthenticatorTransport.BLE: 'ble'>,
  <AuthenticatorTransport.INTERNAL: 'internal'>])
```

Fixes #126.