### PR TITLE
feat/improve-bytes-subclass-mypy-support

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,10 @@
 [mypy]
+plugins = pydantic.mypy
+
 python_version = 3.8
+
+[pydantic-mypy]
+init_typed=True
 
 [mypy-asn1crypto.*]
 ignore_missing_imports = True

--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -18,7 +18,6 @@ from webauthn.helpers.structs import (
     PublicKeyCredentialType,
     TokenBindingStatus,
     WebAuthnBaseModel,
-    BytesLike,
 )
 
 
@@ -27,7 +26,7 @@ class VerifiedAuthentication(WebAuthnBaseModel):
     Information about a verified authentication of which an RP can make use
     """
 
-    credential_id: BytesLike
+    credential_id: bytes
     new_sign_count: int
 
 

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -31,34 +31,6 @@ class WebAuthnBaseModel(BaseModel):
         allow_population_by_field_name = True
 
 
-class BytesLike(bytes):
-    """
-    Custom type to use as an annotation in Pydantic models. This helps us be a better dependency
-    and get along with other libraries like mongoengine that use "clever" bytes subclasses that
-    otherwise act like normal `bytes` type.
-
-    BaseModel properties with this type will accept either `bytes` OR a subclass of `bytes`.
-
-    See the following issues on GitHub for more context:
-
-    - https://github.com/duo-labs/py_webauthn/issues/110
-    - https://github.com/duo-labs/py_webauthn/issues/113
-    """
-
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, v):
-        if isinstance(v, bytes):
-            return v
-        elif isinstance(v, memoryview):
-            return v.tobytes()
-        else:
-            return strict_bytes_validator(v)
-
-
 ################
 #
 # Fundamental data structures
@@ -243,7 +215,7 @@ class PublicKeyCredentialUserEntity(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialuserentity
     """
 
-    id: BytesLike
+    id: bytes
     name: str
     display_name: str
 
@@ -273,7 +245,7 @@ class PublicKeyCredentialDescriptor(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialdescriptor
     """
 
-    id: BytesLike
+    id: bytes
     type: Literal[
         PublicKeyCredentialType.PUBLIC_KEY
     ] = PublicKeyCredentialType.PUBLIC_KEY
@@ -314,7 +286,7 @@ class CollectedClientData(WebAuthnBaseModel):
     """
 
     type: ClientDataType
-    challenge: BytesLike
+    challenge: bytes
     origin: str
     cross_origin: Optional[bool] = None
     token_binding: Optional[TokenBinding] = None
@@ -345,7 +317,7 @@ class PublicKeyCredentialCreationOptions(WebAuthnBaseModel):
 
     rp: PublicKeyCredentialRpEntity
     user: PublicKeyCredentialUserEntity
-    challenge: BytesLike
+    challenge: bytes
     pub_key_cred_params: List[PublicKeyCredentialParameters]
     timeout: Optional[int] = None
     exclude_credentials: Optional[List[PublicKeyCredentialDescriptor]] = None
@@ -363,8 +335,8 @@ class AuthenticatorAttestationResponse(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#authenticatorattestationresponse
     """
 
-    client_data_json: BytesLike
-    attestation_object: BytesLike
+    client_data_json: bytes
+    attestation_object: bytes
 
 
 class RegistrationCredential(WebAuthnBaseModel):
@@ -381,7 +353,7 @@ class RegistrationCredential(WebAuthnBaseModel):
     """
 
     id: str
-    raw_id: BytesLike
+    raw_id: bytes
     response: AuthenticatorAttestationResponse
     transports: Optional[List[AuthenticatorTransport]] = None
     type: Literal[
@@ -436,9 +408,9 @@ class AttestedCredentialData(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#attested-credential-data
     """
 
-    aaguid: BytesLike
-    credential_id: BytesLike
-    credential_public_key: BytesLike
+    aaguid: bytes
+    credential_id: bytes
+    credential_public_key: bytes
 
 
 class AuthenticatorData(WebAuthnBaseModel):
@@ -455,7 +427,7 @@ class AuthenticatorData(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#sctn-attested-credential-data
     """
 
-    rp_id_hash: BytesLike
+    rp_id_hash: bytes
     flags: AuthenticatorDataFlags
     sign_count: int
     attested_credential_data: Optional[AttestedCredentialData] = None
@@ -498,7 +470,7 @@ class PublicKeyCredentialRequestOptions(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options
     """
 
-    challenge: BytesLike
+    challenge: bytes
     timeout: Optional[int] = None
     rp_id: Optional[str] = None
     allow_credentials: Optional[List[PublicKeyCredentialDescriptor]] = []
@@ -519,9 +491,9 @@ class AuthenticatorAssertionResponse(WebAuthnBaseModel):
     https://www.w3.org/TR/webauthn-2/#authenticatorassertionresponse
     """
 
-    client_data_json: BytesLike
-    authenticator_data: BytesLike
-    signature: BytesLike
+    client_data_json: bytes
+    authenticator_data: bytes
+    signature: bytes
     user_handle: Optional[bytes] = None
 
 
@@ -538,7 +510,7 @@ class AuthenticationCredential(WebAuthnBaseModel):
     """
 
     id: str
-    raw_id: BytesLike
+    raw_id: bytes
     response: AuthenticatorAssertionResponse
     type: Literal[
         PublicKeyCredentialType.PUBLIC_KEY

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -42,7 +42,13 @@ class WebAuthnBaseModel(BaseModel):
             return v
 
         if isinstance(v, bytes):
-            # Return raw bytes from subclasses as well
+            """
+            Return raw bytes from subclasses as well
+
+            `strict_bytes_validator()` performs a similar check to this, but it passes through the
+            subclass as-is and Pydantic then rejects it. Passing the subclass into `bytes()` lets us
+            return `bytes` and make Pydantic happy.
+            """
             return bytes(v)
         elif isinstance(v, memoryview):
             return v.tobytes()

--- a/webauthn/registration/verify_registration_response.py
+++ b/webauthn/registration/verify_registration_response.py
@@ -17,7 +17,6 @@ from webauthn.helpers.structs import (
     RegistrationCredential,
     TokenBindingStatus,
     WebAuthnBaseModel,
-    BytesLike,
 )
 from .formats.android_key import verify_android_key
 from .formats.android_safetynet import verify_android_safetynet
@@ -42,14 +41,14 @@ class VerifiedRegistration(WebAuthnBaseModel):
         `attestation_object`: The raw attestation object for later scrutiny
     """
 
-    credential_id: BytesLike
-    credential_public_key: BytesLike
+    credential_id: bytes
+    credential_public_key: bytes
     sign_count: int
     aaguid: str
     fmt: AttestationFormat
     credential_type: PublicKeyCredentialType
     user_verified: bool
-    attestation_object: BytesLike
+    attestation_object: bytes
 
 
 expected_token_binding_statuses = [


### PR DESCRIPTION
Attempting to use the latest py_webauthn in a codebase featuring stricter use of mypy than I'd set up here revealed issues with the use of `BytesLike` as a model field type. Namely, otherwise valid values like `bytes` and `memoryview` were not specifically instances of `BytesLike`, and mypy thus deemed them inappropriate input:

![Screen Shot 2022-04-27 at 11 03 15 AM](https://user-images.githubusercontent.com/5166470/165650363-5a4b0837-3a42-4d29-a331-f28755b52999.png)

After some internal discussion with colleagues I chose to try and refactor the concept of `BytesLike` into types that would appease mypy while also supporting these more advanced bytes-adjacent values. This would aim to restore the ability to define model fields as `bytes` type, which is the type I otherwise want to assign.

This PR adds a new field validator to `WebAuthnBaseModel` that performs the coercion to `bytes` that was previously taken care of with `BytesLike`. This should maintain the core ability to pass in raw `bytes` values while defining Pydantic models in a way that makes mypy happy.

I've also updated this project's mypy config to help catch issues like this in the future.