### PR TITLE
fix/loosen-up-bytes-validation

### DIFF
--- a/tests/test_bytes_subclass_support.py
+++ b/tests/test_bytes_subclass_support.py
@@ -90,3 +90,16 @@ class TestWebAuthnBytesSubclassSupport(TestCase):
         )
 
         assert verification.new_sign_count == 7
+
+    def test_supports_strings_for_bytes(self) -> None:
+        """
+        Preserve the ability to pass strings for `bytes` fields
+        """
+        response = AuthenticatorAssertionResponse(
+            authenticator_data=bytes(),
+            client_data_json=bytes(),
+            signature=bytes(),
+            user_handle='some_user_handle_string'  # type: ignore
+        )
+
+        self.assertEqual(response.user_handle, b'some_user_handle_string')

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -2,7 +2,6 @@ from enum import Enum
 from typing import List, Literal, Optional
 
 from pydantic import BaseModel, validator
-from pydantic.validators import strict_bytes_validator
 from pydantic.fields import ModelField
 
 from .bytes_to_base64url import bytes_to_base64url
@@ -53,7 +52,9 @@ class WebAuthnBaseModel(BaseModel):
         elif isinstance(v, memoryview):
             return v.tobytes()
         else:
-            return strict_bytes_validator(v)
+            # Allow Pydantic to validate the field as usual to support the full range of bytes-like
+            # values
+            return v
 
 ################
 #


### PR DESCRIPTION
I made `bytes` validation too strict in #130. When previously Pydantic was fine, for example, accepting `str` values for `bytes` fields (thanks to `pydantic.validators.bytes_validator`), I opted to use `strict_bytes_validator` which started causing errors in implementations that passed in `str`'s. There's no need to break these implementations so I'm loosening up `WebAuthnBaseModel`'s pre-validator to give Pydantic a chance to validate the field afterwards and coerce these `str` to `bytes` as before.