### PR TITLE
feat/hybrid-transport

### DIFF
--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -72,6 +72,7 @@ class AuthenticatorTransport(str, Enum):
         `BLE`: Bluetooth Low Energy
         `INTERNAL`: Direct connection (read: a platform authenticator)
         `CABLE`: Cloud Assisted Bluetooth Low Energy
+        `HYBRID`: A combination of (often separate) data-transport and proximity mechanisms
 
     https://www.w3.org/TR/webauthn-2/#enum-transport
     """
@@ -81,6 +82,7 @@ class AuthenticatorTransport(str, Enum):
     BLE = "ble"
     INTERNAL = "internal"
     CABLE = "cable"
+    HYBRID = "hybrid"
 
 
 class AuthenticatorAttachment(str, Enum):


### PR DESCRIPTION
Adds the new `"hybrid"` transport in preparation for its addition to the WebAuthn spec (see https://github.com/w3c/webauthn/pull/1755). This new transport is intended to **replace** `"cable"` returned out of `getTransports()`, but `"cable"` is getting left in since credentials with those transports exist in the wild.

Browsers will be responsible for correlating `"cable"` and `"hybrid"`; RP's should not need to change anything about existing credentials, and should continue to treat transports as opaque values to be handed back as-is to browsers during authentication.