### PR TITLE
Add re-export of __init__ imports with __all__

### DIFF
--- a/webauthn/__init__.py
+++ b/webauthn/__init__.py
@@ -9,3 +9,12 @@ from .authentication.verify_authentication_response import (
 from .helpers import base64url_to_bytes, options_to_json
 
 __version__ = "1.7.0"
+
+__all__ = [
+    "generate_registration_options",
+    "verify_registration_response",
+    "generate_authentication_options",
+    "verify_authentication_response",
+    "base64url_to_bytes",
+    "options_to_json",
+]

--- a/webauthn/helpers/__init__.py
+++ b/webauthn/helpers/__init__.py
@@ -1,19 +1,37 @@
-from .aaguid_to_string import aaguid_to_string  # noqa: F401
-from .base64url_to_bytes import base64url_to_bytes  # noqa: F401
-from .bytes_to_base64url import bytes_to_base64url  # noqa: F401
-from .decode_credential_public_key import decode_credential_public_key  # noqa: F401
-from .decoded_public_key_to_cryptography import (  # noqa: F401
-    decoded_public_key_to_cryptography,
-)
-from .generate_challenge import generate_challenge  # noqa: F401
-from .generate_user_handle import generate_user_handle  # noqa: F401
-from .hash_by_alg import hash_by_alg  # noqa: F401
-from .json_loads_base64url_to_bytes import json_loads_base64url_to_bytes  # noqa: F401
-from .options_to_json import options_to_json  # noqa: F401
-from .parse_attestation_object import parse_attestation_object  # noqa: F401
-from .parse_authenticator_data import parse_authenticator_data  # noqa: F401
+from .aaguid_to_string import aaguid_to_string
+from .base64url_to_bytes import base64url_to_bytes
+from .bytes_to_base64url import bytes_to_base64url
+from .decode_credential_public_key import decode_credential_public_key
+from .decoded_public_key_to_cryptography import decoded_public_key_to_cryptography
+from .generate_challenge import generate_challenge
+from .generate_user_handle import generate_user_handle
+from .hash_by_alg import hash_by_alg
+from .json_loads_base64url_to_bytes import json_loads_base64url_to_bytes
+from .options_to_json import options_to_json
+from .parse_attestation_object import parse_attestation_object
+from .parse_authenticator_data import parse_authenticator_data
 from .parse_backup_flags import parse_backup_flags
-from .parse_client_data_json import parse_client_data_json  # noqa: F401
-from .validate_certificate_chain import validate_certificate_chain  # noqa: F401
-from .verify_safetynet_timestamp import verify_safetynet_timestamp  # noqa: F401
-from .verify_signature import verify_signature  # noqa: F401
+from .parse_client_data_json import parse_client_data_json
+from .validate_certificate_chain import validate_certificate_chain
+from .verify_safetynet_timestamp import verify_safetynet_timestamp
+from .verify_signature import verify_signature
+
+__all__ = [
+    "aaguid_to_string",
+    "base64url_to_bytes",
+    "bytes_to_base64url",
+    "decode_credential_public_key",
+    "decoded_public_key_to_cryptography",
+    "generate_challenge",
+    "generate_user_handle",
+    "hash_by_alg",
+    "json_loads_base64url_to_bytes",
+    "options_to_json",
+    "parse_attestation_object",
+    "parse_authenticator_data",
+    "parse_backup_flags",
+    "parse_client_data_json",
+    "validate_certificate_chain",
+    "verify_safetynet_timestamp",
+    "verify_signature",
+]

--- a/webauthn/helpers/tpm/__init__.py
+++ b/webauthn/helpers/tpm/__init__.py
@@ -1,2 +1,4 @@
-from .parse_cert_info import parse_cert_info  # noqa: F401
-from .parse_pub_area import parse_pub_area  # noqa: F401
+from .parse_cert_info import parse_cert_info
+from .parse_pub_area import parse_pub_area
+
+__all__ = ["parse_cert_info", "parse_pub_area"]


### PR DESCRIPTION
Had this issue with mypy in strict mode and figured it could make sense for the webauthn module to expose the methods explicitly and skip the `noqa: F401`.

```
error: Module "webauthn" does not explicitly export attribute "generate_authentication_options"; implicit reexport disabled
...
```