### PR TITLE
feps/update-cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ black==21.9b0
 cbor2==5.4.2.post1
 cffi==1.15.0
 click==8.0.3
-cryptography==36.0.1
+cryptography==39.0.1
 mccabe==0.6.1
 mypy==0.910
 mypy-extensions==0.4.3
@@ -13,7 +13,7 @@ pycodestyle==2.8.0
 pycparser==2.20
 pydantic==1.9.0
 pyflakes==2.4.0
-pyOpenSSL==22.0.0
+pyOpenSSL==23.0.0
 regex==2021.10.8
 six==1.16.0
 toml==0.10.2

--- a/tests/test_validate_certificate_chain.py
+++ b/tests/test_validate_certificate_chain.py
@@ -50,6 +50,7 @@ class TestValidateCertificateChain(TestCase):
         )
         mock_verify_certificate.side_effect = X509StoreContextError(
             "bad root cert",
+            [],
             root_cert_x509,
         )
 

--- a/webauthn/registration/formats/tpm.py
+++ b/webauthn/registration/formats/tpm.py
@@ -250,7 +250,7 @@ def verify_tpm(
     for obj in tcg_at_tpm_values:
         oid = obj.oid.dotted_string
         if oid == "2.23.133.2.1":
-            tcg_at_tpm_manufacturer = obj.value
+            tcg_at_tpm_manufacturer = str(obj.value)
         elif oid == "2.23.133.2.2":
             tcg_at_tpm_model = obj.value
         elif oid == "2.23.133.2.3":


### PR DESCRIPTION
This PR updates the `cryptography` (and `pyOpenSSL`) library based on security advisories urging upgrade to 39.0.1