### PR TITLE
sync-setup-py-install-requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
     install_requires=[
         'asn1crypto>=1.4.0',
         'cbor2>=5.4.2.post1',
-        'cryptography>=36.0.1',
+        'cryptography>=39.0.1',
         'pydantic>=1.9.0',
-        'pyOpenSSL>=22.0.0',
+        'pyOpenSSL>=23.0.0',
     ]
 )


### PR DESCRIPTION
I realized the dependency versions defined in **setup.py** weren't up-to-date with the latest versions set in #148. This fixes that to help identify dependencies that also need to get pulled in for organizations that might vendor this library.