### PR TITLE
update cryptography, pyopenssl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ black==21.9b0
 cbor2==5.4.2.post1
 cffi==1.15.0
 click==8.0.3
-cryptography==39.0.1
+cryptography==41.0.1
 mccabe==0.6.1
 mypy==0.910
 mypy-extensions==0.4.3
@@ -13,7 +13,7 @@ pycodestyle==2.8.0
 pycparser==2.20
 pydantic==1.9.0
 pyflakes==2.4.0
-pyOpenSSL==23.0.0
+pyOpenSSL==23.2.0
 regex==2021.10.8
 six==1.16.0
 toml==0.10.2


### PR DESCRIPTION
Update the cryptography and pyopenssl packages to their latest versions.

This avoids a known vulnerability in v40.0.2 of the cryptography package.