### PR TITLE
fix/delay-pydantic-update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pathspec==0.9.0
 platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
-pydantic>=1.9.0,<2.0a0
+pydantic>=1.10.11,<2.0a0
 pyflakes==2.4.0
 pyOpenSSL==23.2.0
 regex==2021.10.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,11 @@ pathspec==0.9.0
 platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
-pydantic>=1.10.11,<2.0a0
+pydantic==1.10.11
 pyflakes==2.4.0
 pyOpenSSL==23.2.0
 regex==2021.10.8
 six==1.16.0
 toml==0.10.2
 tomli==1.2.1
-typing-extensions==3.10.0.2
+typing-extensions==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pathspec==0.9.0
 platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
-pydantic==1.9.0
+pydantic>=1.9.0,<2.0a0
 pyflakes==2.4.0
 pyOpenSSL==23.2.0
 regex==2021.10.8

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'asn1crypto>=1.4.0',
         'cbor2>=5.4.2.post1',
         'cryptography>=39.0.1',
-        'pydantic>=1.9.0,<2.0a0',
+        'pydantic>=1.10.11,<2.0a0',
         'pyOpenSSL>=23.0.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'asn1crypto>=1.4.0',
         'cbor2>=5.4.2.post1',
         'cryptography>=39.0.1',
-        'pydantic>=1.9.0',
+        'pydantic>=1.9.0,<2.0a0',
         'pyOpenSSL>=23.0.0',
     ]
 )


### PR DESCRIPTION
This PR updates the list of dependencies to keep Pydantic on v1.x for now.

Temporarily addresses #156 till I find time to go through [Pydantic's v2 migration docs](https://docs.pydantic.dev/2.0/migration/) and update this library accordingly.