### PR TITLE
fix/setup-py-dependencies-for-154

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
     install_requires=[
         'asn1crypto>=1.4.0',
         'cbor2>=5.4.2.post1',
-        'cryptography>=39.0.1',
+        'cryptography>=41.0.1',
         'pydantic>=1.10.11,<2.0a0',
-        'pyOpenSSL>=23.0.0',
+        'pyOpenSSL>=23.2.0',
     ]
 )


### PR DESCRIPTION
PR #154 updated cryptography an pyOpenSSL to the latest versions, but only in **requirements.txt**. This PR updates **setup.py** accordingly to keep the two better in-sync.