### PR TITLE
Support both v1 and v2 of Pydantic

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-plugins = pydantic.mypy
+plugins = pydantic.v1.mypy
 
 python_version = 3.8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+annotated-types==0.5.0
 asn1crypto==1.4.0
 black==21.9b0
 cbor2==5.4.2.post1
@@ -11,11 +12,12 @@ pathspec==0.9.0
 platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
-pydantic==1.10.11
+pydantic==2.1.1
+pydantic_core==2.4.0
 pyflakes==2.4.0
 pyOpenSSL==23.2.0
 regex==2021.10.8
 six==1.16.0
 toml==0.10.2
 tomli==1.2.1
-typing-extensions==4.2.0
+typing_extensions==4.7.1

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'asn1crypto>=1.4.0',
         'cbor2>=5.4.2.post1',
         'cryptography>=41.0.1',
-        'pydantic>=1.10.11,<2.0a0',
+        'pydantic>=1.10.11',
         'pyOpenSSL>=23.2.0',
     ]
 )

--- a/webauthn/helpers/decode_credential_public_key.py
+++ b/webauthn/helpers/decode_credential_public_key.py
@@ -1,7 +1,10 @@
 from typing import Union
 
 from cbor2 import decoder
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 from .cose import COSECRV, COSEKTY, COSEAlgorithmIdentifier, COSEKey
 from .exceptions import InvalidPublicKeyStructure, UnsupportedPublicKeyType

--- a/webauthn/helpers/decode_credential_public_key.py
+++ b/webauthn/helpers/decode_credential_public_key.py
@@ -4,7 +4,7 @@ from cbor2 import decoder
 try:
     from pydantic.v1 import BaseModel
 except ImportError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 from .cose import COSECRV, COSEKTY, COSEAlgorithmIdentifier, COSEKey
 from .exceptions import InvalidPublicKeyStructure, UnsupportedPublicKeyType

--- a/webauthn/helpers/parse_backup_flags.py
+++ b/webauthn/helpers/parse_backup_flags.py
@@ -1,5 +1,8 @@
 from enum import Enum
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 from .structs import AuthenticatorDataFlags, CredentialDeviceType
 from .exceptions import InvalidBackupFlags

--- a/webauthn/helpers/parse_backup_flags.py
+++ b/webauthn/helpers/parse_backup_flags.py
@@ -2,7 +2,7 @@ from enum import Enum
 try:
     from pydantic.v1 import BaseModel
 except ImportError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 from .structs import AuthenticatorDataFlags, CredentialDeviceType
 from .exceptions import InvalidBackupFlags

--- a/webauthn/helpers/parse_client_data_json.py
+++ b/webauthn/helpers/parse_client_data_json.py
@@ -1,7 +1,10 @@
 import json
 from json.decoder import JSONDecodeError
 
-from pydantic import ValidationError
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from .base64url_to_bytes import base64url_to_bytes
 from .exceptions import InvalidClientDataJSONStructure

--- a/webauthn/helpers/parse_client_data_json.py
+++ b/webauthn/helpers/parse_client_data_json.py
@@ -4,7 +4,7 @@ from json.decoder import JSONDecodeError
 try:
     from pydantic.v1 import ValidationError
 except ImportError:
-    from pydantic import ValidationError
+    from pydantic import ValidationError  # type: ignore
 
 from .base64url_to_bytes import base64url_to_bytes
 from .exceptions import InvalidClientDataJSONStructure

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -5,8 +5,8 @@ try:
     from pydantic.v1 import BaseModel, validator
     from pydantic.v1.fields import ModelField
 except:
-    from pydantic import BaseModel, validator
-    from pydantic.fields import ModelField
+    from pydantic import BaseModel, validator  # type: ignore
+    from pydantic.fields import ModelField  # type: ignore
 
 from .bytes_to_base64url import bytes_to_base64url
 from .cose import COSEAlgorithmIdentifier

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -1,8 +1,12 @@
 from enum import Enum
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, validator
-from pydantic.fields import ModelField
+try:
+    from pydantic.v1 import BaseModel, validator
+    from pydantic.v1.fields import ModelField
+except:
+    from pydantic import BaseModel, validator
+    from pydantic.fields import ModelField
 
 from .bytes_to_base64url import bytes_to_base64url
 from .cose import COSEAlgorithmIdentifier


### PR DESCRIPTION
One of the nice parts about pydantic v2 is that they provide backward compability by importing from `pydantic.v1`. This adds support so that regardless of which version of pydantic the project is using, py_webauthn will work.