### PR TITLE
Fix handling of optional fields such as user_handle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# PyCharm
+.idea
+
 # pyenv
 .python-version
 


### PR DESCRIPTION
UserHandle is tagged as Optional[bytes] so field.annotation == bytes doesn't match - add explicit match for user_handle.

The conversion from base64 should only be done if input was json - there was a comment to this effect that that didn't work when using parse_raw - but recent releases, using Pydantic 2.0 no longer use those deprecated methods.

closes #174 