### PR TITLE
Use `cbor2.loads` directly to avoid a deprecation warning

### DIFF
--- a/webauthn/helpers/decode_credential_public_key.py
+++ b/webauthn/helpers/decode_credential_public_key.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from cbor2 import decoder
+import cbor2
 from pydantic import BaseModel
 
 from .cose import COSECRV, COSEKTY, COSEAlgorithmIdentifier, COSEKey
@@ -53,7 +53,7 @@ def decode_credential_public_key(
             y=key[33:65],
         )
 
-    decoded_key: dict = decoder.loads(key)
+    decoded_key: dict = cbor2.loads(key)
 
     kty = decoded_key[COSEKey.KTY]
     alg = decoded_key[COSEKey.ALG]


### PR DESCRIPTION
Starting with version 5.5.0 of `cbor2`, importing the `cbor2.decoder` module triggers a deprecation warning. We depend on `cbor2` version 5.4.6 or better which all feature `cbor2.loads` so use it.