### PR TITLE
Add support for subdomain matches in origins

### DIFF
--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -1,70 +1,83 @@
 from unittest import TestCase
 
 from webauthn.helpers.validate_expected_origin import (
-    match_root_domain,
+    is_exact_match,
+    is_wildcard_match,
+    match_origins,
     validate_expected_origin,
 )
 
 
 class TestValidateExpectedOrigin(TestCase):
 
-    def  test_validate_origins(self):
-        # orgin, expected_origin, result
-        test_data = [
-            # root domain match
-            ("https://example.org", ["https://example.org", "https://login.example.org"], True),
-            # subdomain match
-            ("https://login.example.org", ["https://example.org", "https://login.example.org"], True),
-            # match on non-HTTP scheme (from w3c docs)
-            ("example-os:appid:204ffa", ["https://example.org", "example-os:appid:204ffa"], True),
-            # subdomain not found in list
-            ("https://fail.example.org", ["https://example.org", "https://login.example.org"], False),
-            # subdomain fails on exact root domain main
-            ("https://fail.example.org", "https://example.org", False),
-            # subdomain passes on wildcard match
-            ("https://fail.example.org", "https://*.example.org", True),
-            # root domain failes on wildcard match
-            ("https://example.org", "https://*.example.org", False),
+    def test_is_exact_match(self):
+        """Test for case insensitive exact match."""
+        expected_origin_result = [
+            # exact match
+            ("https://www.example.org", "https://www.example.org", True),
+            # case insensitive match
+            ("https://www.EXAMPLE.org", "https://www.example.org", True),
+            # check subdomain fails on exact match
+            ("https://example.org", "https://www.example.org", False),
         ]
-        for origin, expected_origin, result in test_data:
-            self.assertEqual(
-                validate_expected_origin(expected_origin, origin),
-                result,
-                "Expected {} to match {}".format(origin, expected_origin)
-            )
+        for expected, origin, result in expected_origin_result:
+            match = is_exact_match(expected, origin)
+            self.assertEqual(match, result, "{} != {}".format(origin, expected))
 
-    def test_match_root_domain(self):
-        test_data = [
+    def test_is_wildcard_match(self):
+        """Test for http(s) wildcard match."""
+        expected_origin_result = [
             # subdomain passes on wildcard match
-            ("https://pass.example.org", "https://*.example.org", True),
+            ("https://*.example.org", "https://pass.example.org", True),
             # subdomain passes with a port
-            ("https://pass.example.org:8000", "https://*.example.org:8000", True),
+            ("https://*.example.org:8000", "https://pass.example.org:8000", True),
             # root domain fails on wildcard match
-            ("https://example.org", "https://*.example.org", False),
+            ("https://*.example.org", "https://example.org", False),
             # subdomain fails on scheme mismatch
-            ("http://fail.example.org", "https://*.example.org", False),
+            ("https://*.example.org", "http://fail.example.org", False),
             # subdomain fails on port mismatch
-            ("https://fail.example.org:8000", "https://*.example.org:8001", False),
+            ("https://*.example.org:8001", "https://fail.example.org:8000", False),
+            ("https://*.example.org", "https://fail.example.org:80", False),
+            ("https://*.example.org:80", "https://fail.example.org", False),
+            # unsupported scheme
+            ("file://path/to/*/example.org", "file://path/to/*/example.org", False),
+            # unsupported scheme
+            ("file://path/to/*/example.org", "file://path/to/*/example.org", False),
+            # not a wildcard - exact match
+            ("https://example.org", "https://example.org", True),
         ]
-        for origin, wildcard, result in test_data:
-            self.assertEqual(
-                match_root_domain(wildcard, origin),
-                result,
-                "Expected {} to match {}".format(origin, wildcard)
-            )
+        for expected, origin, result in expected_origin_result:
+            match = is_wildcard_match(expected, origin)
+            self.assertEqual(match, result, "{} != {}".format(origin, expected))
 
-    def test_match_root_domain__errors(self):
-        # check for origins that do not support wildcards
-        origins = (
-            # invalid scheme
-            "file://*.example.com",
-            # missing wildcard
-            "https://example.org",
-        )
-        for invalid_origin in origins:
-            self.assertRaises(
-                ValueError,
-                match_root_domain,
-                invalid_origin,
-                "https://foo.example.com"
-            )
+    def test_match_origins(self):
+        """Test for combined match (exact and wildcard)."""
+        expected_origin_result = [
+            # exact match
+            ("https://www.example.org", "https://www.example.org", True),
+            # wildcard match
+            ("https://*.example.org", "https://pass.example.org", True),
+            # no match
+            ("https://foo.example.org", "https://bar.example.org", False),
+        ]
+        for expected, origin, result in expected_origin_result:
+            match = match_origins(expected, origin)
+            self.assertEqual(match, result, "{} != {}".format(origin, expected))
+
+    def validate_expected_origin(self):
+        # test that validation handles a str or a list
+        expected_origin_result = [
+            # single str match
+            ("https://www.example.org", "https://www.example.org", True),
+            # list match
+            ("https://www.example.org", ["https://www.example.org"], True),
+            # list match
+            ("https://www.example.org", ["https://example.org", "https://www.example.org"], True),
+            # single str mismatch
+            ("https://www.example.org", "https://foo.example.org", False),
+            # list mismatch
+            ("https://www.example.org", ["https://foo.example.org"], False),
+        ]
+        for expected, origin, result in expected_origin_result:
+            match = validate_expected_origin(expected, origin)
+            self.assertEqual(match, result, "{} != {}".format(origin, expected))

--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
 
+from webauthn.helpers.exceptions import InvalidExpectedOrigin
 from webauthn.helpers.validate_expected_origin import (
-    is_exact_match,
-    is_wildcard_match,
     match_origins,
     validate_expected_origin,
 )
@@ -10,45 +9,6 @@ from webauthn.helpers.validate_expected_origin import (
 
 class TestValidateExpectedOrigin(TestCase):
 
-    def test_is_exact_match(self):
-        """Test for case insensitive exact match."""
-        expected_origin_result = [
-            # exact match
-            ("https://www.example.org", "https://www.example.org", True),
-            # case insensitive match
-            ("https://www.EXAMPLE.org", "https://www.example.org", True),
-            # check subdomain fails on exact match
-            ("https://example.org", "https://www.example.org", False),
-        ]
-        for expected, origin, result in expected_origin_result:
-            match = is_exact_match(expected, origin)
-            self.assertEqual(match, result, "{} != {}".format(origin, expected))
-
-    def test_is_wildcard_match(self):
-        """Test for http(s) wildcard match."""
-        expected_origin_result = [
-            # subdomain passes on wildcard match
-            ("https://*.example.org", "https://pass.example.org", True),
-            # subdomain passes with a port
-            ("https://*.example.org:8000", "https://pass.example.org:8000", True),
-            # root domain fails on wildcard match
-            ("https://*.example.org", "https://example.org", False),
-            # subdomain fails on scheme mismatch
-            ("https://*.example.org", "http://fail.example.org", False),
-            # subdomain fails on port mismatch
-            ("https://*.example.org:8001", "https://fail.example.org:8000", False),
-            ("https://*.example.org", "https://fail.example.org:80", False),
-            ("https://*.example.org:80", "https://fail.example.org", False),
-            # unsupported scheme
-            ("file://path/to/*/example.org", "file://path/to/*/example.org", False),
-            # unsupported scheme
-            ("file://path/to/*/example.org", "file://path/to/*/example.org", False),
-            # not a wildcard - exact match
-            ("https://example.org", "https://example.org", True),
-        ]
-        for expected, origin, result in expected_origin_result:
-            match = is_wildcard_match(expected, origin)
-            self.assertEqual(match, result, "{} != {}".format(origin, expected))
 
     def test_match_origins(self):
         """Test for combined match (exact and wildcard)."""
@@ -57,8 +17,18 @@ class TestValidateExpectedOrigin(TestCase):
             ("https://www.example.org", "https://www.example.org", True),
             # wildcard match
             ("https://*.example.org", "https://pass.example.org", True),
+            # global wildcard match
+            ("*", "http://any-old-url", True),
             # no match
             ("https://foo.example.org", "https://bar.example.org", False),
+            # subdomain passes with a port
+            ("https://*.example.org:8000", "https://pass.example.org:8000", True),
+            # root domain fails on wildcard match
+            ("https://*.example.org", "https://example.org", False),
+            # subdomain fails on scheme mismatch
+            ("https://example.org", "http://example.org", False),
+            # subdomain fails on port mismatch
+            ("https://example.org:8001", "https://example.org:8000", False),
         ]
         for expected, origin, result in expected_origin_result:
             match = match_origins(expected, origin)
@@ -81,3 +51,6 @@ class TestValidateExpectedOrigin(TestCase):
         for expected, origin, result in expected_origin_result:
             match = validate_expected_origin(expected, origin)
             self.assertEqual(match, result, "{} != {}".format(origin, expected))
+
+    def test_invalid_expected_origin(self) -> None:
+        self.assertRaises(InvalidExpectedOrigin, match_origins, "**", "https://www.example.org")

--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -27,7 +27,9 @@ class TestValidateExpectedOrigin(TestCase):
             ("https://example.org", "https://*.example.org", False),
         ]
         for origin, expected_origin, result in test_data:
-            assert validate_expected_origin(expected_origin, origin) == result, (
+            self.assertEqual(
+                validate_expected_origin(expected_origin, origin),
+                result,
                 "Expected {} to match {}".format(origin, expected_origin)
             )
 
@@ -45,7 +47,9 @@ class TestValidateExpectedOrigin(TestCase):
             ("https://fail.example.org:8000", "https://*.example.org:8001", False),
         ]
         for origin, wildcard, result in test_data:
-            assert match_root_domain(wildcard, origin) == result, (
+            self.assertEqual(
+                match_root_domain(wildcard, origin),
+                result,
                 "Expected {} to match {}".format(origin, wildcard)
             )
 

--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -19,6 +19,12 @@ class TestValidateExpectedOrigin(TestCase):
         ("https://www.example.com", "https://*.example.com", True),
         # subdomain allowed becuase of wildcard, no scheme in expected
         ("https://www.example.com", "*.example.com", True),
+        # subdomain allowed becuase of wildcard, no scheme in expected
+        ("https://www.example.com", "*.example.com", True),
+        # match with port number
+        ("https://example.com:8000", ["example.com:8000","example.com:8001"], True),
+        # no match with port number
+        ("https://example.com:8001", "example.com:8000", False),
     ]
 
     def  test_validate_origins(self):

--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from webauthn.helpers.validate_expected_origin import (
-    match_wildcard_origin,
+    match_root_domain,
     validate_expected_origin,
 )
 
@@ -10,48 +10,57 @@ class TestValidateExpectedOrigin(TestCase):
 
     def  test_validate_origins(self):
         # orgin, expected_origin, result
-        matches = [
-            # straight match
-            ("https://example.com", "https://example.com", True),
-            # subdomain does not match
-            ("https://www.example.com", "https://example.com", False),
-            # straight match with a list
-            ("https://example.com", ["https://foo.bar.com", "https://example.com"], True),
-            # subdomain does not match with a list
-            ("https://www.example.com", ["https://foo.bar.com", "https://example.com"], False),
-            # subdomain allowed because of wildcard
-            ("https://www.example.com", "https://*.example.com", True),
-            # scheme mismatch
-            ("http://www.example.com", "https://www.example.com", False),
+        test_data = [
+            # root domain match
+            ("https://example.org", ["https://example.org", "https://login.example.org"], True),
+            # subdomain match
+            ("https://login.example.org", ["https://example.org", "https://login.example.org"], True),
+            # match on non-HTTP scheme (from w3c docs)
+            ("example-os:appid:204ffa", ["https://example.org", "example-os:appid:204ffa"], True),
+            # subdomain not found in list
+            ("https://fail.example.org", ["https://example.org", "https://login.example.org"], False),
+            # subdomain fails on exact root domain main
+            ("https://fail.example.org", "https://example.org", False),
+            # subdomain passes on wildcard match
+            ("https://fail.example.org", "https://*.example.org", True),
+            # root domain failes on wildcard match
+            ("https://example.org", "https://*.example.org", False),
         ]
-        for origin, expected_origin, result in matches:
-            is_match = validate_expected_origin(expected_origin, origin)
-            assert is_match == result, "Expected {} to match {}".format(
-                origin, expected_origin
-            )
-
-    def  test_match_origin(self):
-       # Test the match_origin function handles strings and lists of strings
-        matches = [
-            # straight match
-            ("https://example.com", "https://example.com", True),
-            # straight match with a list
-            ("https://example.com", ["https://foo.bar.com", "https://example.com"], True),
-        ]
-        for origin, expected_origin, result in matches:
-            is_match = validate_expected_origin(expected_origin, origin)
-            assert is_match == result, (
+        for origin, expected_origin, result in test_data:
+            assert validate_expected_origin(expected_origin, origin) == result, (
                 "Expected {} to match {}".format(origin, expected_origin)
             )
 
-    def test_match_wildcard_origin(self):
-        matches = (
-            ("https://*.example.com", "https://foo.example.com", True),
-            ("https://*.example.com:8000", "https://foo.example.com:8000",True),
-            # wildcard does not match if there is no subdomain
-            ("https://*.example.com", "https://example.com", False),
+    def test_match_root_domain(self):
+        test_data = [
+            # subdomain passes on wildcard match
+            ("https://pass.example.org", "https://*.example.org", True),
+            # subdomain passes with a port
+            ("https://pass.example.org:8000", "https://*.example.org:8000", True),
+            # root domain fails on wildcard match
+            ("https://example.org", "https://*.example.org", False),
+            # subdomain fails on scheme mismatch
+            ("http://fail.example.org", "https://*.example.org", False),
+            # subdomain fails on port mismatch
+            ("https://fail.example.org:8000", "https://*.example.org:8001", False),
+        ]
+        for origin, wildcard, result in test_data:
+            assert match_root_domain(wildcard, origin) == result, (
+                "Expected {} to match {}".format(origin, wildcard)
+            )
+
+    def test_match_root_domain__errors(self):
+        # check for origins that do not support wildcards
+        origins = (
+            # invalid scheme
+            "file://*.example.com",
+            # missing wildcard
+            "https://example.org",
         )
-        for expected_origin, origin, result in matches:
-            assert result == match_wildcard_origin(expected_origin, origin), (
-                "Expected {} to match {}".format(origin, expected_origin)
+        for invalid_origin in origins:
+            self.assertRaises(
+                ValueError,
+                match_root_domain,
+                invalid_origin,
+                "https://foo.example.com"
             )

--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -13,20 +13,16 @@ class TestValidateExpectedOrigin(TestCase):
         matches = [
             # straight match
             ("https://example.com", "https://example.com", True),
-            # straight match with a list
-            ("https://example.com", ["https://foo.bar.com", "https://example.com"], True),
             # subdomain does not match
             ("https://www.example.com", "https://example.com", False),
+            # straight match with a list
+            ("https://example.com", ["https://foo.bar.com", "https://example.com"], True),
             # subdomain does not match with a list
             ("https://www.example.com", ["https://foo.bar.com", "https://example.com"], False),
             # subdomain allowed because of wildcard
             ("https://www.example.com", "https://*.example.com", True),
-            # subdomain allowed because of wildcard, no scheme in expected
-            ("https://www.example.com", "*.example.com", True),
-            # match with port number
-            ("https://example.com:8000", ["example.com:8000","example.com:8001"], True),
-            # no match with port number
-            ("https://example.com:8001", "example.com:8000", False),
+            # scheme mismatch
+            ("http://www.example.com", "https://www.example.com", False),
         ]
         for origin, expected_origin, result in matches:
             is_match = validate_expected_origin(expected_origin, origin)
@@ -51,8 +47,7 @@ class TestValidateExpectedOrigin(TestCase):
     def test_match_wildcard_origin(self):
         matches = (
             ("https://*.example.com", "https://foo.example.com", True),
-            ("*.example.com", "https://foo.example.com",True),
-            ("*.example.com:8000", "https://foo.example.com:8000",True),
+            ("https://*.example.com:8000", "https://foo.example.com:8000",True),
             # wildcard does not match if there is no subdomain
             ("https://*.example.com", "https://example.com", False),
         )

--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-from webauthn.helpers.exceptions import InvalidExpectedOrigin
 from webauthn.helpers.validate_expected_origin import (
     match_origins,
     validate_expected_origin,
@@ -31,6 +30,8 @@ class TestValidateExpectedOrigin(TestCase):
             ("https://example.org:8001", "https://example.org:8000", False),
             # wildcard subdomain fails root domain match
             ("https://*.example.org", "https://example.org", False),
+            # invalid expected origin
+            ("https://*.*.example.org", "https://foo.bar.example.org", False),
         ]
         for expected, origin, result in expected_origin_result:
             match = match_origins(expected, origin)
@@ -49,15 +50,12 @@ class TestValidateExpectedOrigin(TestCase):
             ("https://www.example.org", "https://foo.example.org", False),
             # list mismatch
             ("https://www.example.org", ["https://foo.example.org"], False),
+            # empty expected origin
+            ("https://www.example.org", [], False),
+            ("https://www.example.org", "", False),
+            # invalid expected origin
+            ("https://www.example.org", 99, False),
         ]
         for expected, origin, result in expected_origin_result:
             match = validate_expected_origin(expected, origin)
             self.assertEqual(match, result, "{} != {}".format(origin, expected))
-
-    def test_invalid_expected_origin(self) -> None:
-        self.assertRaises(
-            InvalidExpectedOrigin,
-            match_origins,
-            "http://*.*.example.org",
-            "https://www.example.org",
-        )

--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from webauthn.helpers.validate_expected_origin import validate_expected_origin
+
+
+class TestValidateExpectedOrigin(TestCase):
+
+    # orgin, expected_origin, result
+    TEST_PARAMS = [
+        # straight match
+        ("https://example.com", "https://example.com", True),
+        # straight match with a list
+        ("https://example.com", ["https://foo.bar.com", "https://example.com"], True),
+        # subdomain does not match
+        ("https://www.example.com", "https://example.com", False),
+        # subdomain does not match with a list
+        ("https://www.example.com", ["https://foo.bar.com", "https://example.com"], False),
+        # subdomain allowed becuase of wildcard
+        ("https://www.example.com", "https://*.example.com", True),
+        # subdomain allowed becuase of wildcard, no scheme in expected
+        ("https://www.example.com", "*.example.com", True),
+    ]
+
+    def  test_validate_origins(self):
+        for origin, expected_origin, result in self.TEST_PARAMS:
+            is_match = validate_expected_origin(expected_origin, origin)
+            self.assertEqual(is_match, result)
+
+    def  test_invalid_origins(self):
+        # should raise ValueError as it's not HTTPS
+        validate_expected_origin("example.com", "example.com")

--- a/tests/test_validate_expected_origin.py
+++ b/tests/test_validate_expected_origin.py
@@ -26,6 +26,8 @@ class TestValidateExpectedOrigin(TestCase):
             is_match = validate_expected_origin(expected_origin, origin)
             self.assertEqual(is_match, result)
 
-    def  test_invalid_origins(self):
-        # should raise ValueError as it's not HTTPS
-        validate_expected_origin("example.com", "example.com")
+    # TODO: add test for invalid expected_origin once we have regenerated the
+    #       test data
+    # def  test_invalid_origins(self):
+    #     # should raise ValueError as it's not HTTPS
+    #     validate_expected_origin("example.com", "example.com")

--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -7,10 +7,11 @@ from webauthn.helpers import (
     bytes_to_base64url,
     decode_credential_public_key,
     decoded_public_key_to_cryptography,
+    parse_authentication_credential_json,
     parse_authenticator_data,
     parse_backup_flags,
     parse_client_data_json,
-    parse_authentication_credential_json,
+    validate_expected_origin,
     verify_signature,
 )
 from webauthn.helpers.exceptions import InvalidAuthenticationResponse
@@ -102,18 +103,10 @@ def verify_authentication_response(
             "Client data challenge was not expected challenge"
         )
 
-    if isinstance(expected_origin, str):
-        if expected_origin != client_data.origin:
-            raise InvalidAuthenticationResponse(
-                f'Unexpected client data origin "{client_data.origin}", expected "{expected_origin}"'
-            )
-    else:
-        try:
-            expected_origin.index(client_data.origin)
-        except ValueError:
-            raise InvalidAuthenticationResponse(
-                f'Unexpected client data origin "{client_data.origin}", expected one of {expected_origin}'
-            )
+    if not validate_expected_origin(expected_origin, client_data.origin):
+        raise InvalidAuthenticationResponse(
+            f'Unexpected client data origin "{client_data.origin}", expected "{expected_origin}"'
+        )
 
     if client_data.token_binding:
         status = client_data.token_binding.status

--- a/webauthn/helpers/__init__.py
+++ b/webauthn/helpers/__init__.py
@@ -16,6 +16,7 @@ from .parse_cbor import parse_cbor
 from .parse_client_data_json import parse_client_data_json
 from .parse_registration_credential_json import parse_registration_credential_json
 from .validate_certificate_chain import validate_certificate_chain
+from .validate_expected_origin import validate_expected_origin
 from .verify_safetynet_timestamp import verify_safetynet_timestamp
 from .verify_signature import verify_signature
 
@@ -38,6 +39,7 @@ __all__ = [
     "parse_client_data_json",
     "parse_registration_credential_json",
     "validate_certificate_chain",
+    "validate_expected_origin",
     "verify_safetynet_timestamp",
     "verify_signature",
 ]

--- a/webauthn/helpers/exceptions.py
+++ b/webauthn/helpers/exceptions.py
@@ -56,7 +56,3 @@ class InvalidBackupFlags(Exception):
 
 class InvalidCBORData(Exception):
     pass
-
-
-class InvalidExpectedOrigin(Exception):
-    pass

--- a/webauthn/helpers/exceptions.py
+++ b/webauthn/helpers/exceptions.py
@@ -6,6 +6,10 @@ class InvalidAuthenticationResponse(Exception):
     pass
 
 
+class InvalidExpectedOrigin(Exception):
+    pass
+
+
 class InvalidPublicKeyStructure(Exception):
     pass
 

--- a/webauthn/helpers/exceptions.py
+++ b/webauthn/helpers/exceptions.py
@@ -56,3 +56,7 @@ class InvalidBackupFlags(Exception):
 
 class InvalidCBORData(Exception):
     pass
+
+
+class InvalidExpectedOrigin(Exception):
+    pass

--- a/webauthn/helpers/validate_expected_origin.py
+++ b/webauthn/helpers/validate_expected_origin.py
@@ -1,0 +1,51 @@
+from typing import List, Union
+
+
+def normalize_origin(origin: str) -> str:
+    return origin.lower().lstrip("https://")
+
+
+def match_origin(expected_origin: str, origin: str) -> bool:
+    """
+    Match a single origin against an expected origin.
+
+    This function handles the subdomain wildcard, so that an expected
+    origin of "https://*.example.com" will match "https://foo.example.com".
+
+    """
+    # normalize both origins to make it easier to compare
+    origin1 = normalize_origin(expected_origin)
+    origin2 = normalize_origin(origin)
+    if "*" not in origin1:
+        return origin1 == origin2
+    # we have a wildcard, so we need to do some extra work.
+    return origin2.endswith(origin1.split("*")[1])
+
+
+def validate_expected_origin(
+        expected_origin: Union[str, List[str]],
+        origin: str
+    ) -> bool:
+    """
+    Validate that the origin matches the expected origin.
+
+    Args:
+        `expected_origin`: The origin that is expected - may be a string
+            or list of strings, any of which may include the "*"
+            wildcard to match any subdomain.
+        `origin`: The origin to validate, must be HTTPS.
+
+    Raises:
+        `ValueError` if origin does not match expected origin, or if
+        origin is not HTTPS.
+
+    """
+    # TODO: Breaks tests - need to regenerate test data
+    # if not origin.startswith("https://"):
+    #     raise ValueError(f"Origin '{origin}' must start with https://")
+
+    # convert single string to list so we can treat all the same
+    if isinstance(expected_origin, str):
+        return match_origin(expected_origin, origin)
+
+    return any(match_origin(expected, origin) for expected in expected_origin)

--- a/webauthn/helpers/validate_expected_origin.py
+++ b/webauthn/helpers/validate_expected_origin.py
@@ -1,8 +1,95 @@
+"""
+Validation of the origin passed in via ClientDataJSON.
+
+See https://www.w3.org/TR/webauthn-3/#sctn-validating-origin
+
+---
+The Relying Party MUST NOT accept unexpected values of origin, as doing
+so could allow a malicious website to obtain valid credentials. Although
+the scope of WebAuthn credentials prevents their use on domains outside
+the RP ID they were registered for, the Relying Party's origin
+validation serves as an additional layer of protection in case a faulty
+authenticator fails to enforce credential scope. See also §13.4.8 Code
+injection attacks for discussion of potentially malicious subdomains.
+
+Validation MAY be performed by exact string matching or any other method
+as needed by the Relying Party. For example:
+
+- A web application served only at https://example.org SHOULD require
+origin to exactly equal https://example.org.
+
+This is the simplest case, where origin is expected to be the string
+https:// followed by the RP ID.
+
+- A web application served at a small number of domains might require
+origin to exactly equal some element of a list of allowed origins, for
+example the list ["https://example.org", "https://login.example.org"].
+
+- A web application served at a large set of domains that changes often
+might parse origin structurally and require that the URL scheme is https
+and that the authority equals or is any subdomain of the RP ID - for
+example, example.org or any subdomain of example.org).
+
+NOTE: See §13.4.8 Code injection attacks for a discussion of the risks
+of allowing any subdomain of the RP ID.
+
+A web application with a companion native application might allow origin
+to be an operating system dependent identifier for the native
+application. For example, such a Relying Party might require that origin
+exactly equals some element of the list ["https://example.org",
+"example-os:appid:204ffa1a5af110ac483f131a1bef8a841a7a"].
+
+"""
 from typing import List, Union
+from urllib.parse import urlparse
+
+WILDCARD_DELIMITER = "*."
 
 
-def normalize_origin(origin: str) -> str:
-    return origin.lower().lstrip("https://")
+def match_wildcard_origin(origin1: str, origin2: str) -> bool:
+    """
+    Perform wildcard match of two origins.
+
+    This covers the case where the expected origin has a "*." prefix
+    on the domain, allowing subdomains to match.
+
+    e.g. https://*.example.com will match https://foo.example.com, but
+    not https://example.com. The expected origin may also be a bare
+    domain, e.g. example.com, which will match https://example.com.
+
+    If the scheme is missing from the expected origin, it will be
+    inferred from the origin2 parameter.
+
+    If the port number is supplied for either origin then they must
+    match.
+
+    See tests for more examples.
+
+    Args:
+        `origin1`: The origin that contains the wildcard ("*").
+        `origin2`: The (fully-qualified) origin to match with.
+
+    """
+    if WILDCARD_DELIMITER not in origin1:
+        return False
+
+    # urlparse will not parse a hostname without a scheme, so we need to
+    # add the "//" prefix if scheme is missing.
+    parts1 = urlparse(origin1) if "//" in origin1 else urlparse("//" + origin1)
+    parts2 = urlparse(origin2)
+
+    # if we have a scheme for both origins, they must match
+    if (parts1.scheme and parts2.scheme) and parts1.scheme != parts2.scheme:
+        return False
+
+    # if either origin has a port number, they must match
+    if (parts1.port or parts2.port) and parts1.port != parts2.port:
+        return False
+
+    # split off wildcard part of origin1 and check origin2 ends with it
+    suffix = origin1.rsplit(WILDCARD_DELIMITER, 1)[1]
+    # NB "*.example.com" should not match "example.com"
+    return origin2.endswith(suffix) and not origin2 == suffix
 
 
 def match_origin(expected_origin: str, origin: str) -> bool:
@@ -12,18 +99,22 @@ def match_origin(expected_origin: str, origin: str) -> bool:
     This function handles the subdomain wildcard, so that an expected
     origin of "https://*.example.com" will match "https://foo.example.com".
 
+    Args:
+        `expected_origin`: The origin that is expected - which may include
+            the "*" wildcard to match any subdomain.
+        `origin`: The (fully-qualified) origin to validate.
+
     """
-    # normalize both origins to make it easier to compare
-    origin1 = normalize_origin(expected_origin)
-    origin2 = normalize_origin(origin)
-    if "*" not in origin1:
-        return origin1 == origin2
-    # we have a wildcard, so we check for subdomains.
-    # this is a very blunt check - we make no attempt to
-    # parse the url, we just check that the origin ends with
-    # the expected origin after the wildcard - so will hoover
-    # up port numbers as well. See tests for examples.
-    return origin2.endswith(origin1.split("*")[1])
+    # straight match
+    if origin == expected_origin:
+        return True
+
+    # expected origin doesn't have a scheme, check for suffix
+    if origin.endswith(expected_origin):
+        return True
+
+    # check for a wildcard match - involves parsing url
+    return match_wildcard_origin(expected_origin, origin)
 
 
 def validate_expected_origin(
@@ -33,21 +124,15 @@ def validate_expected_origin(
     """
     Validate that the origin matches the expected origin.
 
+    See https://www.w3.org/TR/webauthn-3/#sctn-validating-origin
+
     Args:
         `expected_origin`: The origin that is expected - may be a string
             or list of strings, any of which may include the "*"
             wildcard to match any subdomain.
-        `origin`: The origin to validate, must be HTTPS.
-
-    Raises:
-        `ValueError` if origin does not match expected origin, or if
-        origin is not HTTPS.
+        `origin`: The (fully-qualified) origin to validate.
 
     """
-    # TODO: Breaks tests - need to regenerate test data
-    # if not origin.startswith("https://"):
-    #     raise ValueError(f"Origin '{origin}' must start with https://")
-
     # convert single string to list so we can treat all the same
     if isinstance(expected_origin, str):
         return match_origin(expected_origin, origin)

--- a/webauthn/helpers/validate_expected_origin.py
+++ b/webauthn/helpers/validate_expected_origin.py
@@ -18,7 +18,11 @@ def match_origin(expected_origin: str, origin: str) -> bool:
     origin2 = normalize_origin(origin)
     if "*" not in origin1:
         return origin1 == origin2
-    # we have a wildcard, so we need to do some extra work.
+    # we have a wildcard, so we check for subdomains.
+    # this is a very blunt check - we make no attempt to
+    # parse the url, we just check that the origin ends with
+    # the expected origin after the wildcard - so will hoover
+    # up port numbers as well. See tests for examples.
     return origin2.endswith(origin1.split("*")[1])
 
 

--- a/webauthn/helpers/validate_expected_origin.py
+++ b/webauthn/helpers/validate_expected_origin.py
@@ -98,16 +98,13 @@ def match_origin(expected_origin: str, origin: str) -> bool:
 
     Args:
         `expected_origin`: The origin that is expected - which may include
-            the "*" wildcard to match any subdomain.
-        `origin`: The (fully-qualified) origin to validate.
+            the "*" wildcard to match any subdomain. Must include scheme.
+        `origin`: The (fully-qualified) origin to validate, as returned by
+            the browser in the ClientDataJSON.
 
     """
     # straight match
     if origin == expected_origin:
-        return True
-
-    # expected origin doesn't have a scheme, check for suffix
-    if origin.endswith(expected_origin):
         return True
 
     # check for a wildcard match - involves parsing url


### PR DESCRIPTION
Fixes #182 

I have added a new helper function to wrap up validation of `expected_origin` in the registration and authentication verify functions. This function handles straight str:str matches, str:list[str] matches, and a new subdomain match.

The subdomain match relies on a sentinel value of `"*"` as a wildcard to indicate that subdomains are supported. e.g. if `exepected_origin="https://*.example.com"` then the verify functions will accept "foo.example.com".

RP ID | Expected origin | Client data origin | Result
-- | -- | -- | --
example.com | https://example.com | https://example.com | match
example.com | https://*.example.com | https://foo.example.com | wildcard match
example.com | https://*.example.com | https://example.com | no wildcard match

This is the origin of the update:

> The Relying Party **MUST** validate the origin member of the client data.
>
> The Relying Party **MUST NOT** accept unexpected values of origin.

and

> Validation **MAY** be performed by exact string matching or <ins>**any other method**</ins> as needed by the Relying Party.

This PR addresses the "any other method" point by supporting a wildcard in the expected origin value. It doesn't do any structural parsing (scheme, host, domain, port) - it just does a straight str match on the prefix / suffix generated by splitting the expected origin with a wildcard character ("*").

NB This does mean that a simple "*" as the expected origin will match anything.

_From https://w3c.github.io/webauthn/#sctn-validating-origin_
