### PR TITLE
feat/user_id_bytes_only

### DIFF
--- a/tests/test_options_to_json.py
+++ b/tests/test_options_to_json.py
@@ -22,7 +22,7 @@ class TestWebAuthnOptionsToJSON(TestCase):
         options = generate_registration_options(
             rp_id="example.com",
             rp_name="Example Co",
-            user_id="ABAV6QWPBEY9WOTOA1A4",
+            user_id=bytes([1, 2, 3, 4]),
             user_name="lee",
             user_display_name="Lee",
             attestation=AttestationConveyancePreference.DIRECT,
@@ -45,7 +45,7 @@ class TestWebAuthnOptionsToJSON(TestCase):
             {
                 "rp": {"name": "Example Co", "id": "example.com"},
                 "user": {
-                    "id": "QUJBVjZRV1BCRVk5V09UT0ExQTQ",
+                    "id": "AQIDBA",
                     "name": "lee",
                     "displayName": "Lee",
                 },
@@ -67,7 +67,6 @@ class TestWebAuthnOptionsToJSON(TestCase):
         options = generate_registration_options(
             rp_id="example.com",
             rp_name="Example Co",
-            user_id="ABAV6QWPBEY9WOTOA1A4",
             user_name="lee",
             exclude_credentials=[
                 PublicKeyCredentialDescriptor(

--- a/tests/test_parse_authentication_credential_json.py
+++ b/tests/test_parse_authentication_credential_json.py
@@ -166,7 +166,7 @@ class TestParseClientDataJSON(TestCase):
 
     def test_raises_on_non_base64url_raw_id(self) -> None:
         with self.assertRaisesRegex(
-            InvalidAuthenticationResponse, "Unable to parse authentication credential"
+            InvalidAuthenticationResponse, "Could not parse authentication credential"
         ):
             parse_authentication_credential_json(
                 {
@@ -183,7 +183,7 @@ class TestParseClientDataJSON(TestCase):
 
     def test_raises_on_non_base64url_authenticator_data(self) -> None:
         with self.assertRaisesRegex(
-            InvalidAuthenticationResponse, "Unable to parse authentication credential"
+            InvalidAuthenticationResponse, "Could not parse authentication credential"
         ):
             parse_authentication_credential_json(
                 {
@@ -200,7 +200,7 @@ class TestParseClientDataJSON(TestCase):
 
     def test_raises_on_non_base64url_client_data_json(self) -> None:
         with self.assertRaisesRegex(
-            InvalidAuthenticationResponse, "Unable to parse authentication credential"
+            InvalidAuthenticationResponse, "Could not parse authentication credential"
         ):
             parse_authentication_credential_json(
                 {
@@ -217,7 +217,7 @@ class TestParseClientDataJSON(TestCase):
 
     def test_raises_on_non_base64url_signature(self) -> None:
         with self.assertRaisesRegex(
-            InvalidAuthenticationResponse, "Unable to parse authentication credential"
+            InvalidAuthenticationResponse, "Could not parse authentication credential"
         ):
             parse_authentication_credential_json(
                 {

--- a/tests/test_parse_authentication_credential_json.py
+++ b/tests/test_parse_authentication_credential_json.py
@@ -146,7 +146,7 @@ class TestParseClientDataJSON(TestCase):
             }
         )
 
-        self.assertEqual(parsed.response.user_handle, "bW1pbGxlcg")
+        self.assertEqual(parsed.response.user_handle, base64url_to_bytes("bW1pbGxlcg"))
 
     def test_handles_missing_user_handle(self) -> None:
         parsed = parse_authentication_credential_json(
@@ -265,7 +265,7 @@ class TestParseClientDataJSON(TestCase):
                 "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiSjlyUFpWWnFWODlUSW53bzV3cU11R3dlZjdET0pZRi1OVHlMQnhHV2pjZi16amFzOFRTUTlMbXI3em4wSmpkMTQyMU1sV0ItS2JYdEs5RW5sN19JM3ciLCJvcmlnaW4iOiJodHRwczovL3dlYmF1dGhuLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
             ),
         )
-        self.assertEqual(parsed.response.user_handle, "bW1pbGxlcg")
+        self.assertEqual(parsed.response.user_handle, base64url_to_bytes("bW1pbGxlcg"))
         self.assertEqual(parsed.type, "public-key")
         self.assertEqual(parsed.authenticator_attachment, AuthenticatorAttachment.PLATFORM)
 
@@ -302,6 +302,6 @@ class TestParseClientDataJSON(TestCase):
                 "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiSjlyUFpWWnFWODlUSW53bzV3cU11R3dlZjdET0pZRi1OVHlMQnhHV2pjZi16amFzOFRTUTlMbXI3em4wSmpkMTQyMU1sV0ItS2JYdEs5RW5sN19JM3ciLCJvcmlnaW4iOiJodHRwczovL3dlYmF1dGhuLmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlfQ"
             ),
         )
-        self.assertEqual(parsed.response.user_handle, "bW1pbGxlcg")
+        self.assertEqual(parsed.response.user_handle, base64url_to_bytes("bW1pbGxlcg"))
         self.assertEqual(parsed.type, "public-key")
         self.assertEqual(parsed.authenticator_attachment, AuthenticatorAttachment.PLATFORM)

--- a/tests/test_parse_registration_credential_json.py
+++ b/tests/test_parse_registration_credential_json.py
@@ -165,7 +165,7 @@ class TestParseClientDataJSON(TestCase):
 
     def test_raises_on_non_base64url_raw_id(self) -> None:
         with self.assertRaisesRegex(
-            InvalidRegistrationResponse, "Unable to parse registration credential"
+            InvalidRegistrationResponse, "Could not parse registration credential"
         ):
             parse_registration_credential_json(
                 {
@@ -181,7 +181,7 @@ class TestParseClientDataJSON(TestCase):
 
     def test_raises_on_non_base64url_attestation_object(self) -> None:
         with self.assertRaisesRegex(
-            InvalidRegistrationResponse, "Unable to parse registration credential"
+            InvalidRegistrationResponse, "Could not parse registration credential"
         ):
             parse_registration_credential_json(
                 {
@@ -197,7 +197,7 @@ class TestParseClientDataJSON(TestCase):
 
     def test_raises_on_non_base64url_client_data_json(self) -> None:
         with self.assertRaisesRegex(
-            InvalidRegistrationResponse, "Unable to parse registration credential"
+            InvalidRegistrationResponse, "Could not parse registration credential"
         ):
             parse_registration_credential_json(
                 {

--- a/webauthn/helpers/options_to_json.py
+++ b/webauthn/helpers/options_to_json.py
@@ -23,13 +23,10 @@ def options_to_json(
             _rp["id"] = options.rp.id
 
         _user: Dict[str, Any] = {
+            "id": bytes_to_base64url(options.user.id),
             "name": options.user.name,
             "displayName": options.user.display_name,
         }
-        if isinstance(options.user.id, bytes):
-            _user["id"] = bytes_to_base64url(options.user.id)
-        else:
-            _user["id"] = options.user.id
 
         reg_to_return: Dict[str, Any] = {
             "rp": _rp,

--- a/webauthn/helpers/parse_authentication_credential_json.py
+++ b/webauthn/helpers/parse_authentication_credential_json.py
@@ -24,7 +24,7 @@ def parse_authentication_credential_json(json_val: Union[str, dict]) -> Authenti
             raise InvalidJSONStructure("Unable to decode credential as JSON")
 
     if not isinstance(json_val, dict):
-        raise InvalidJSONStructure("Credential is not a JSON object")
+        raise InvalidJSONStructure("Credential was not a JSON object")
 
     cred_id = json_val.get("id")
     if not isinstance(cred_id, str):
@@ -66,7 +66,7 @@ def parse_authentication_credential_json(json_val: Union[str, dict]) -> Authenti
         response_user_handle = base64url_to_bytes(response_user_handle)
     elif response_user_handle is not None:
         # If it's not a string, and it's not None, then it's definitely not valid
-        raise InvalidJSONStructure("Credential response ha unexpected userHandle")
+        raise InvalidJSONStructure("Credential response had unexpected userHandle")
 
     cred_authenticator_attachment = json_val.get("authenticatorAttachment")
     if isinstance(cred_authenticator_attachment, str):
@@ -74,7 +74,7 @@ def parse_authentication_credential_json(json_val: Union[str, dict]) -> Authenti
             cred_authenticator_attachment = AuthenticatorAttachment(cred_authenticator_attachment)
         except ValueError as cred_attachment_exc:
             raise InvalidJSONStructure(
-                "Credential has unexpected authenticatorAttachment"
+                "Credential had unexpected authenticatorAttachment"
             ) from cred_attachment_exc
     else:
         cred_authenticator_attachment = None
@@ -94,7 +94,7 @@ def parse_authentication_credential_json(json_val: Union[str, dict]) -> Authenti
         )
     except Exception as exc:
         raise InvalidAuthenticationResponse(
-            "Unable to parse authentication credential from JSON data"
+            "Could not parse authentication credential from JSON data"
         ) from exc
 
     return authentication_credential

--- a/webauthn/helpers/parse_registration_credential_json.py
+++ b/webauthn/helpers/parse_registration_credential_json.py
@@ -25,7 +25,7 @@ def parse_registration_credential_json(json_val: Union[str, dict]) -> Registrati
             raise InvalidJSONStructure("Unable to decode credential as JSON")
 
     if not isinstance(json_val, dict):
-        raise InvalidJSONStructure("Credential is not a JSON object")
+        raise InvalidJSONStructure("Credential was not a JSON object")
 
     cred_id = json_val.get("id")
     if not isinstance(cred_id, str):
@@ -72,7 +72,7 @@ def parse_registration_credential_json(json_val: Union[str, dict]) -> Registrati
             cred_authenticator_attachment = AuthenticatorAttachment(cred_authenticator_attachment)
         except ValueError as cred_attachment_exc:
             raise InvalidJSONStructure(
-                "Credential has unexpected authenticatorAttachment"
+                "Credential had unexpected authenticatorAttachment"
             ) from cred_attachment_exc
     else:
         cred_authenticator_attachment = None
@@ -91,7 +91,7 @@ def parse_registration_credential_json(json_val: Union[str, dict]) -> Registrati
         )
     except Exception as exc:
         raise InvalidRegistrationResponse(
-            "Unable to parse registration credential from JSON data"
+            "Could not parse registration credential from JSON data"
         ) from exc
 
     return registration_credential

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -187,7 +187,7 @@ class PublicKeyCredentialUserEntity:
     """Information about a user of a Relying Party.
 
     Attributes:
-        `id`: An "opaque byte sequence" that uniquely identifies a user. Typically something like a UUID, but never user-identifying like an email address. Cannot exceed 64 bytes.
+        `id`: An "opaque byte sequence" that uniquely identifies a user. Typically something like a UUID, but never user-identifying like an email address. Cannot exceed 64 bytes. These bytes should be stored internally alongside your normal user identifier and only used for WebAuthn.
         `name`: A value which a user can see to determine which account this credential is associated with. A username or email address is fine here.
         `display_name`: A user-friendly representation of a user, like a full name.
 


### PR DESCRIPTION
This PR only accepts `bytes` for the `user_id` argument when calling `generate_registration_options()`. Additionally, `user_id` is now **OPTIONAL**; when omitted 64 random bytes will be generated and used for this value.

Fixes #187.