### PR TITLE
fix/document-default-challenge-length

### DIFF
--- a/tests/test_generate_challenge.py
+++ b/tests/test_generate_challenge.py
@@ -7,11 +7,11 @@ class TestWebAuthnGenerateChallenge(TestCase):
     def test_generates_byte_sequence(self) -> None:
         output = generate_challenge()
 
-        assert type(output) == bytes
-        assert len(output) == 64
+        self.assertEqual(type(output), bytes)
+        self.assertEqual(len(output), 64)
 
     def test_generates_unique_value_each_time(self) -> None:
         output1 = generate_challenge()
         output2 = generate_challenge()
 
-        assert output1 != output2
+        self.assertNotEqual(output1, output2)

--- a/tests/test_generate_challenge.py
+++ b/tests/test_generate_challenge.py
@@ -15,8 +15,3 @@ class TestWebAuthnGenerateChallenge(TestCase):
         output2 = generate_challenge()
 
         assert output1 != output2
-
-    def test_supports_custom_lengths(self) -> None:
-        output = generate_challenge(32)
-
-        assert len(output) == 32

--- a/webauthn/authentication/generate_authentication_options.py
+++ b/webauthn/authentication/generate_authentication_options.py
@@ -20,7 +20,7 @@ def generate_authentication_options(
 
     Args:
         `rp_id`: The Relying Party's unique identifier as specified in attestations.
-        (optional) `challenge`: A byte sequence for the authenticator to return back in its response. If no value is specified then a sequence of random bytes will be generated.
+        (optional) `challenge`: A byte sequence for the authenticator to return back in its response. Defaults to 64 random bytes.
         (optional) `timeout`: How long in milliseconds the browser should give the user to choose an authenticator. This value is a *hint* and may be ignored by the browser.
         (optional) `allow_credentials`: A list of credentials registered to the user.
         (optional) `user_verification`: The RP's preference for the authenticator's enforcement of the "user verified" flag.

--- a/webauthn/helpers/generate_challenge.py
+++ b/webauthn/helpers/generate_challenge.py
@@ -1,8 +1,12 @@
 import secrets
 
 
-def generate_challenge(length: int = 64) -> bytes:
+def generate_challenge() -> bytes:
     """
-    Generate a random authenticator challenge
+    Create a random value for the authenticator to sign, going above and beyond the recommended
+    number of random bytes as per https://www.w3.org/TR/webauthn-2/#sctn-cryptographic-challenges:
+
+    "In order to prevent replay attacks, the challenges MUST contain enough entropy to make
+    guessing them infeasible. Challenges SHOULD therefore be at least 16 bytes long."
     """
-    return secrets.token_bytes(length)
+    return secrets.token_bytes(64)

--- a/webauthn/registration/generate_registration_options.py
+++ b/webauthn/registration/generate_registration_options.py
@@ -61,7 +61,7 @@ def generate_registration_options(
         `user_name`: A value that will help the user identify which account this credential is associated with. Can be an email address, etc...
         (optional) `user_id`: A collection of random bytes that identify a user account. For privacy reasons it should NOT be something like an email address. Defaults to 64 random bytes.
         (optional) `user_display_name`: A user-friendly representation of their account. Can be a full name ,etc... Defaults to the value of `user_name`.
-        (optional) `challenge`: A byte sequence for the authenticator to return back in its response. If no value is specified then a sequence of random bytes will be generated.
+        (optional) `challenge`: A byte sequence for the authenticator to return back in its response. Defaults to 64 random bytes.
         (optional) `timeout`: How long in milliseconds the browser should give the user to choose an authenticator. This value is a *hint* and may be ignored by the browser.
         (optional) `attestation`: The level of attestation to be provided by the authenticator.
         (optional) `authenticator_selection`: Require certain characteristics about an authenticator, like attachment, support for resident keys, user verification, etc...


### PR DESCRIPTION
This PR adds more documentation on default challenge length when this library generates the challenge (i.e. no value for `challenge` when calling `generate_registration_options()` and `generate_authentication_options()`)

Fixes #188.