### PR TITLE
Update to cryptography 42.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ black==21.9b0
 cbor2==5.5.0
 cffi==1.15.0
 click==8.0.3
-cryptography==41.0.7
+cryptography==42.0.5
 mccabe==0.6.1
 mypy==1.4.1
 mypy-extensions==1.0.0
@@ -12,7 +12,7 @@ platformdirs==2.4.0
 pycodestyle==2.8.0
 pycparser==2.20
 pyflakes==2.4.0
-pyOpenSSL==23.3.0
+pyOpenSSL==24.1.0
 regex==2021.10.8
 six==1.16.0
 toml==0.10.2


### PR DESCRIPTION
This PR supersedes #207 by including a version bump to pyOpenSSL to `24.1.0` when updating cryptography to `42.0.5`.