### PR TITLE
feat/add-smart-card-transport

### DIFF
--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -248,9 +248,9 @@ class AuthenticatorSelectionCriteria:
     authenticator_attachment: Optional[AuthenticatorAttachment] = None
     resident_key: Optional[ResidentKeyRequirement] = None
     require_resident_key: Optional[bool] = False
-    user_verification: Optional[
-        UserVerificationRequirement
-    ] = UserVerificationRequirement.PREFERRED
+    user_verification: Optional[UserVerificationRequirement] = (
+        UserVerificationRequirement.PREFERRED
+    )
 
 
 @dataclass
@@ -470,9 +470,9 @@ class PublicKeyCredentialRequestOptions:
     timeout: Optional[int] = None
     rp_id: Optional[str] = None
     allow_credentials: Optional[List[PublicKeyCredentialDescriptor]] = None
-    user_verification: Optional[
-        UserVerificationRequirement
-    ] = UserVerificationRequirement.PREFERRED
+    user_verification: Optional[UserVerificationRequirement] = (
+        UserVerificationRequirement.PREFERRED
+    )
 
 
 @dataclass

--- a/webauthn/helpers/structs.py
+++ b/webauthn/helpers/structs.py
@@ -29,6 +29,7 @@ class AuthenticatorTransport(str, Enum):
     USB = "usb"
     NFC = "nfc"
     BLE = "ble"
+    SMART_CARD = "smart-card"
     INTERNAL = "internal"
     CABLE = "cable"
     HYBRID = "hybrid"


### PR DESCRIPTION
This PR adds the recently-added `"smart-card"` transport that's currently defined in the L3 editor's draft:

https://w3c.github.io/webauthn/#dom-authenticatortransport-smart-card