### PR TITLE
authentication: return user verified flag

### DIFF
--- a/tests/test_verify_authentication_response.py
+++ b/tests/test_verify_authentication_response.py
@@ -43,6 +43,7 @@ class TestVerifyAuthenticationResponse(TestCase):
         assert verification.new_sign_count == 78
         assert verification.credential_backed_up == False
         assert verification.credential_device_type == "single_device"
+        assert not verification.user_verified
 
     def test_verify_authentication_response_with_RSA_public_key(self):
         credential = """{
@@ -78,6 +79,7 @@ class TestVerifyAuthenticationResponse(TestCase):
         )
 
         assert verification.new_sign_count == 1
+        assert verification.user_verified
 
     def test_raises_exception_on_incorrect_public_key(self):
         credential = """{

--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -35,6 +35,7 @@ class VerifiedAuthentication:
     new_sign_count: int
     credential_device_type: CredentialDeviceType
     credential_backed_up: bool
+    user_verified: bool
 
 
 expected_token_binding_statuses = [
@@ -180,4 +181,5 @@ def verify_authentication_response(
         new_sign_count=auth_data.sign_count,
         credential_device_type=parsed_backup_flags.credential_device_type,
         credential_backed_up=parsed_backup_flags.credential_backed_up,
+        user_verified=auth_data.flags.uv,
     )


### PR DESCRIPTION
Some other libs like webauthn-rs enforce that when user verification is only preferred and that a device previously performed user verification, it must continue to perform it on later authentication, as it proved that it was user verification capable. Whether this out-of-spec check is desirable is an open question, however if someone wants to align behavior between a webauthn-rs-based implem and a py_webauthn implem then returning this information is necessary.