### PR TITLE
Figure out how to specify a datetime during attestation verification tests

### DIFF
--- a/tests/helpers/x509store.py
+++ b/tests/helpers/x509store.py
@@ -30,7 +30,7 @@ def patch_validate_certificate_chain_x509store_getter(func):
     ```
     """
 
-    def wrapper_inner(*args, **kwargs):
+    def wrapper(*args, **kwargs):
         """
         Using `inspect.getmodule(...)` below helps deal with the fact that, in Python 3.9 and
         Python 3.10, `@patch("webauthn.helpers.validate_certificate_chain._generate_new_cert_store")`
@@ -45,4 +45,4 @@ def patch_validate_certificate_chain_x509store_getter(func):
             mock_generate_new_cert_store.return_value = new_cert_store
             return func(*args, new_cert_store, **kwargs)
 
-    return wrapper_inner
+    return wrapper

--- a/tests/helpers/x509store.py
+++ b/tests/helpers/x509store.py
@@ -1,0 +1,48 @@
+import inspect
+from unittest.mock import patch
+
+from OpenSSL.crypto import X509Store
+from webauthn.helpers import validate_certificate_chain
+
+
+def patch_validate_certificate_chain_x509store_getter(func):
+    """
+    This is a very purpose-built decorator to help set a fixed time for X.509 certificate validation
+    in unittests. It makes the following assumptions, all of which must be true for this to
+    decorator to remain useful:
+
+    - x5c certificate chain validation occurs in **webauthn/helpers/validate_certificate_chain.py::**`validate_certificate_chain`
+    - `validate_certificate_chain(...)` uses `OpenSSL.crypto.X509Store` to verify certificate chains
+    - **webauthn/helpers/__init__.py** continues to re-export `validate_certificate_chain`
+
+    Usage:
+
+    ```py
+    from unittest import TestCase
+    from datetime import datetime
+    from OpenSSL.crypto import X509Store
+
+    class TestX509Validation(TestCase):
+        @patch_validate_certificate_chain_x509store_getter
+        def test_validate_x509_chain(self, patched_x509store: X509Store):
+            patched_x509store.set_time(datetime(2021, 9, 1, 0, 0, 0))
+            # ...
+    ```
+    """
+
+    def wrapper_inner(*args, **kwargs):
+        """
+        Using `inspect.getmodule(...)` below helps deal with the fact that, in Python 3.9 and
+        Python 3.10, `@patch("webauthn.helpers.validate_certificate_chain._generate_new_cert_store")`
+        errors out because `webauthn.helpers.validate_certificate_chain` is understood to be the method
+        re-exported via `__all__` in **webauthn/helpers/__init__.py**, not the module of the same name.
+        """
+        with patch.object(
+            inspect.getmodule(validate_certificate_chain),
+            "_generate_new_cert_store",
+        ) as mock_generate_new_cert_store:
+            new_cert_store = X509Store()
+            mock_generate_new_cert_store.return_value = new_cert_store
+            return func(*args, new_cert_store, **kwargs)
+
+    return wrapper_inner

--- a/tests/helpers/x509store.py
+++ b/tests/helpers/x509store.py
@@ -7,17 +7,17 @@ from webauthn.helpers import validate_certificate_chain
 
 def patch_validate_certificate_chain_x509store_getter(func):
     """
-    This is a very purpose-built decorator to help set a fixed time for X.509 certificate validation
-    in unittests. It makes the following assumptions, all of which must be true for this to
+    This is a very purpose-built decorator to help set a fixed time for X.509 certificate chain
+    validation in unittests. It makes the following assumptions, all of which must be true for this
     decorator to remain useful:
 
-    - x5c certificate chain validation occurs in **webauthn/helpers/validate_certificate_chain.py::**`validate_certificate_chain`
+    - X.509 certificate chain validation occurs in **webauthn/helpers/validate_certificate_chain.py::**`validate_certificate_chain`
     - `validate_certificate_chain(...)` uses `OpenSSL.crypto.X509Store` to verify certificate chains
     - **webauthn/helpers/__init__.py** continues to re-export `validate_certificate_chain`
 
     Usage:
 
-    ```py
+    ```
     from unittest import TestCase
     from datetime import datetime
     from OpenSSL.crypto import X509Store

--- a/tests/test_validate_certificate_chain.py
+++ b/tests/test_validate_certificate_chain.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from datetime import datetime
+import inspect
 
 from webauthn.helpers.exceptions import InvalidCertificateChain
 from webauthn.helpers.known_root_certs import (
@@ -33,7 +34,7 @@ class TestValidateCertificateChain(TestCase):
         # (Root) 20200318182132Z <-> 20450315000000Z
         self.cert_store.set_time(datetime(2021, 9, 1, 0, 0, 0))
 
-    @patch("webauthn.helpers.validate_certificate_chain._generate_new_cert_store")
+    @patch.object(inspect.getmodule(validate_certificate_chain), "_generate_new_cert_store")
     def test_validates_certificate_chain(self, _mock_generate_new_cert_store: MagicMock) -> None:
         _mock_generate_new_cert_store.return_value = self.cert_store
 

--- a/tests/test_validate_certificate_chain.py
+++ b/tests/test_validate_certificate_chain.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
+from datetime import datetime
 
-from cryptography.hazmat.backends import default_backend
-from cryptography.x509 import load_pem_x509_certificate
 from webauthn.helpers.exceptions import InvalidCertificateChain
 from webauthn.helpers.known_root_certs import (
     apple_webauthn_root_ca,
@@ -11,12 +10,14 @@ from webauthn.helpers.known_root_certs import (
 from webauthn.helpers.validate_certificate_chain import (
     validate_certificate_chain,
 )
-from OpenSSL.crypto import X509, X509StoreContextError
+from OpenSSL.crypto import X509Store
 
 apple_x5c_certs = [
+    # 2021-08-31 @ 23:02:07Z <-> 2021-09-03 @ 23:02:07Z
     bytes.fromhex(
         "30820243308201c9a0030201020206017ba3992221300a06082a8648ce3d0403023048311c301a06035504030c134170706c6520576562417574686e204341203131133011060355040a0c0a4170706c6520496e632e3113301106035504080c0a43616c69666f726e6961301e170d3231303833313233303230375a170d3231303930333233303230375a3081913149304706035504030c4062313066373138626335646437353838383661316438636662356238623633313732396634643765346261303639616230613939326331633038343738616639311a3018060355040b0c114141412043657274696669636174696f6e31133011060355040a0c0a4170706c6520496e632e3113301106035504080c0a43616c69666f726e69613059301306072a8648ce3d020106082a8648ce3d03010703420004d124b0e9ff8192723c9ee2fa4f8170d373e03286cf880aeec7008a14cdea64724963e05bb8c44a9f980ded12aa8a33795cf81d31e74116ced6f1f4c5eb0c358fa3553053300c0603551d130101ff04023000300e0603551d0f0101ff0404030204f0303306092a864886f76364080204263024a1220420e457e5bc292f1635210248ed2e776ba129c7cc469524a75356836caef2f058a0300a06082a8648ce3d0403020368003065023065c6e7075ddacb50879a8412904759013d0da78726408759a01f1994c1795a69c2c1d11306c2d1bc97be6141627b8677023100ab0b9e7d97ca2b603b1edb6e264c49bf1971380c2afa5d37f8c4ff5a5de6d457a19cb80c02b2edf94b0853e0482f8686"
     ),
+    # 2020-03-18 @ 18:38:01Z <-> 2030-03-13 @ 00:00:00Z
     bytes.fromhex(
         "30820234308201baa003020102021056255395c7a7fb40ebe228d8260853b6300a06082a8648ce3d040303304b311f301d06035504030c164170706c6520576562417574686e20526f6f7420434131133011060355040a0c0a4170706c6520496e632e3113301106035504080c0a43616c69666f726e6961301e170d3230303331383138333830315a170d3330303331333030303030305a3048311c301a06035504030c134170706c6520576562417574686e204341203131133011060355040a0c0a4170706c6520496e632e3113301106035504080c0a43616c69666f726e69613076301006072a8648ce3d020106052b8104002203620004832e872f261491810225b9f5fcd6bb6378b5f55f3fcb045bc735993475fd549044df9bfe19211765c69a1dda050b38d45083401a434fb24d112d56c3e1cfbfcb9891fec0696081bef96cbc77c88dddaf46a5aee1dd515b5afaab93be9c0b2691a366306430120603551d130101ff040830060101ff020100301f0603551d2304183016801426d764d9c578c25a67d1a7de6b12d01b63f1c6d7301d0603551d0e04160414ebae82c4ffa1ac5b51d4cf24610500be63bd7788300e0603551d0f0101ff040403020106300a06082a8648ce3d0403030368003065023100dd8b1a3481a5fad9dbb4e7657b841e144c27b75b876a4186c2b1475750337227efe554457ef648950c632e5c483e70c102302c8a6044dc201fcfe59bc34d2930c1487851d960ed6a75f1eb4acabe38cd25b897d0c805bef0c7f78b07a571c6e80e07"
     ),
@@ -24,12 +25,17 @@ apple_x5c_certs = [
 
 
 class TestValidateCertificateChain(TestCase):
-    # TODO: Revisit these tests when we figure out how to generate dynamic certs that
-    # won't start failing tests 72 hours after creation...
-    @patch("OpenSSL.crypto.X509StoreContext.verify_certificate")
-    def test_validates_certificate_chain(self, mock_verify_certificate: MagicMock) -> None:
-        # Mocked because these certs actually expired and started failing this test
-        mock_verify_certificate.return_value = True
+    def setUp(self):
+        self.cert_store = X509Store()
+        # Setting the time to something that satisfies all these:
+        # (Leaf) 20210831230207Z <-> 20210903230207Z <- Earliest expiration
+        # (Int.) 20200318183801Z <-> 20300313000000Z
+        # (Root) 20200318182132Z <-> 20450315000000Z
+        self.cert_store.set_time(datetime(2021, 9, 1, 0, 0, 0))
+
+    @patch("webauthn.helpers.validate_certificate_chain._generate_new_cert_store")
+    def test_validates_certificate_chain(self, _mock_generate_new_cert_store: MagicMock) -> None:
+        _mock_generate_new_cert_store.return_value = self.cert_store
 
         try:
             validate_certificate_chain(
@@ -40,17 +46,9 @@ class TestValidateCertificateChain(TestCase):
             print(err)
             self.fail("validate_certificate_chain failed when it should have succeeded")
 
-    @patch("OpenSSL.crypto.X509StoreContext.verify_certificate")
-    def test_throws_on_bad_root_cert(self, mock_verify_certificate: MagicMock) -> None:
-        # Mocked because these certs actually expired and started failing this test
-        root_cert_x509 = X509().from_cryptography(
-            load_pem_x509_certificate(globalsign_root_ca, default_backend())
-        )
-        mock_verify_certificate.side_effect = X509StoreContextError(
-            "bad root cert",
-            [],
-            root_cert_x509,
-        )
+    @patch("webauthn.helpers.validate_certificate_chain._generate_new_cert_store")
+    def test_throws_on_bad_root_cert(self, _mock_generate_new_cert_store: MagicMock) -> None:
+        _mock_generate_new_cert_store.return_value = self.cert_store
 
         with self.assertRaises(InvalidCertificateChain):
             validate_certificate_chain(

--- a/tests/test_verify_registration_response_android_key.py
+++ b/tests/test_verify_registration_response_android_key.py
@@ -1,22 +1,19 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 from datetime import datetime
-
 from OpenSSL.crypto import X509Store
 
 from webauthn.helpers import base64url_to_bytes
 from webauthn.helpers.structs import AttestationFormat
 from webauthn import verify_registration_response
 
+from .helpers.x509store import patch_validate_certificate_chain_x509store_getter
+
 
 class TestVerifyRegistrationResponseAndroidKey(TestCase):
-    def setUp(self):
-        self.cert_store = X509Store()
-
-    @patch("webauthn.helpers.validate_certificate_chain._generate_new_cert_store")
+    @patch_validate_certificate_chain_x509store_getter
     def test_verify_attestation_android_key_hardware_authority(
         self,
-        mock_generate_new_cert_store: MagicMock,
+        patched_x509store: X509Store,
     ) -> None:
         """
         This android-key attestation was generated on a Pixel 8a in January 2025 via an origin
@@ -50,8 +47,7 @@ class TestVerifyRegistrationResponseAndroidKey(TestCase):
         # (Int.) 20241209062853Z <-> 20250217062852Z
         # (Int.) 20220126224945Z <-> 20370122224945Z
         # (Root) 20191122203758Z <-> 20341118203758Z
-        self.cert_store.set_time(datetime(2025, 1, 8, 0, 0, 0))
-        mock_generate_new_cert_store.return_value = self.cert_store
+        patched_x509store.set_time(datetime(2025, 1, 8, 0, 0, 0))
 
         verification = verify_registration_response(
             credential=credential,

--- a/tests/test_verify_registration_response_android_safetynet.py
+++ b/tests/test_verify_registration_response_android_safetynet.py
@@ -11,23 +11,19 @@ from webauthn.registration.formats.android_safetynet import (
     verify_android_safetynet,
 )
 
+from .helpers.x509store import patch_validate_certificate_chain_x509store_getter
+
 
 class TestVerifyRegistrationResponseAndroidSafetyNet(TestCase):
-    def setUp(self):
-        self.cert_store = X509Store()
-
-    @patch("webauthn.helpers.validate_certificate_chain._generate_new_cert_store")
-    def test_verify_attestation_android_safetynet(
-        self, mock_generate_new_cert_store: MagicMock
-    ) -> None:
+    @patch_validate_certificate_chain_x509store_getter
+    def test_verify_attestation_android_safetynet(self, patched_x509store: X509Store) -> None:
         # Setting the time to something that satisfies all these:
         # (Leaf) 20210719131342Z <-> 20211017131341Z <- Earliest expiration
         # (Int.) 20200813000042Z <-> 20270930000042Z
         # (Int.) 20200619000042Z <-> 20280128000042Z
         # (Root) 20061215080000Z <-> 20211215080000Z
         # (Root) 19980901120000Z <-> 20280128120000Z
-        self.cert_store.set_time(datetime(2021, 9, 1, 0, 0, 0))
-        mock_generate_new_cert_store.return_value = self.cert_store
+        patched_x509store.set_time(datetime(2021, 9, 1, 0, 0, 0))
 
         credential = parse_registration_credential_json(
             """{

--- a/tests/test_verify_registration_response_apple.py
+++ b/tests/test_verify_registration_response_apple.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 from datetime import datetime
 
 from OpenSSL.crypto import X509Store
@@ -8,20 +7,20 @@ from webauthn.helpers import base64url_to_bytes
 from webauthn.helpers.structs import AttestationFormat
 from webauthn import verify_registration_response
 
+from .helpers.x509store import patch_validate_certificate_chain_x509store_getter
+
 
 class TestVerifyRegistrationResponseApple(TestCase):
-    @patch("webauthn.helpers.validate_certificate_chain._generate_new_cert_store")
+    @patch_validate_certificate_chain_x509store_getter
     def test_verify_attestation_apple_passkey(
         self,
-        mock_generate_new_cert_store: MagicMock,
+        patched_x509store: X509Store,
     ) -> None:
-        cert_store = X509Store()
         # Setting the time to something that satisfies all these:
         # (Leaf) 20210831230207Z <-> 20210903230207Z <- Earliest expiration
         # (Int.) 20200318183801Z <-> 20300313000000Z
         # (Root) 20200318182132Z <-> 20450315000000Z
-        cert_store.set_time(datetime(2021, 9, 1, 0, 0, 0))
-        mock_generate_new_cert_store.return_value = cert_store
+        patched_x509store.set_time(datetime(2021, 9, 1, 0, 0, 0))
 
         credential = """{
             "id": "0yhsKG_gCzynIgNbvXWkqJKL8Uc",


### PR DESCRIPTION
There's been a long-standing TODO within attestation-specific unittests to figure out how to specify the time so that x5c certificate validation can succeed even after a certificate in the chain has expired. To date the tests patched the actual "verify cert chain" call to simply return `True` because otherwise most tests would fail with "certificate expired"-like errors. This obscured detection of other potential issues with the X.509 certificates, though, and so I've always wanted to find a better solution.

This issue rose to the top recently while addressing #243. I decided to take another look at potential solutions when I stumbled upon https://github.com/pyca/pyopenssl/issues/735. This called out the `set_time()` method available on instances of pyOpenSSL's `X509Store`. After some trial and error, I settled on a pattern to enable specifying a datetime in the past, to a time between all cert's `notBefore` and `notAfter` values.

This PR adds a new `webauthn.helpers.validate_certificate_chain._generate_new_cert_store` method that can be patched using `unittest.mock.patch` to return a custom `X509Store` instance with a fixed `datetime.datetime`. Related TODOs in unittests have been updated to leverage this new-found capability and ultimately increase confidence in existing attestation tests.