### PR TITLE
Remove use of cryptography's `default_backend()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ celerybeat-schedule
 .env
 .venv
 env/
-venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/webauthn/helpers/decoded_public_key_to_cryptography.py
+++ b/webauthn/helpers/decoded_public_key_to_cryptography.py
@@ -1,7 +1,6 @@
 import codecs
 from typing import Union
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePublicKey,
     EllipticCurvePublicNumbers,
@@ -35,7 +34,7 @@ def decoded_public_key_to_cryptography(
         y = int(codecs.encode(public_key.y, "hex"), 16)
         curve = get_ec2_curve(public_key.crv)
 
-        ecc_pub_key = EllipticCurvePublicNumbers(x, y, curve).public_key(default_backend())
+        ecc_pub_key = EllipticCurvePublicNumbers(x, y, curve).public_key()
 
         return ecc_pub_key
     elif isinstance(public_key, DecodedRSAPublicKey):
@@ -46,7 +45,7 @@ def decoded_public_key_to_cryptography(
         e = int(codecs.encode(public_key.e, "hex"), 16)
         n = int(codecs.encode(public_key.n, "hex"), 16)
 
-        rsa_pub_key = RSAPublicNumbers(e, n).public_key(default_backend())
+        rsa_pub_key = RSAPublicNumbers(e, n).public_key()
 
         return rsa_pub_key
     elif isinstance(public_key, DecodedOKPPublicKey):

--- a/webauthn/helpers/pem_cert_bytes_to_open_ssl_x509.py
+++ b/webauthn/helpers/pem_cert_bytes_to_open_ssl_x509.py
@@ -1,4 +1,3 @@
-from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_pem_x509_certificate
 from OpenSSL.crypto import X509
 
@@ -7,6 +6,6 @@ def pem_cert_bytes_to_open_ssl_x509(cert: bytes) -> X509:
     """Convert PEM-formatted certificate bytes into an X509 instance usable for cert
     chain validation
     """
-    cert_crypto = load_pem_x509_certificate(cert, default_backend())
+    cert_crypto = load_pem_x509_certificate(cert)
     cert_openssl = X509().from_cryptography(cert_crypto)
     return cert_openssl

--- a/webauthn/helpers/validate_certificate_chain.py
+++ b/webauthn/helpers/validate_certificate_chain.py
@@ -1,6 +1,5 @@
 from typing import List, Optional
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_der_x509_certificate
 from OpenSSL.crypto import X509, X509Store, X509StoreContext, X509StoreContextError
 
@@ -34,7 +33,7 @@ def validate_certificate_chain(
     # Prepare leaf cert
     try:
         leaf_cert_bytes = x5c[0]
-        leaf_cert_crypto = load_der_x509_certificate(leaf_cert_bytes, default_backend())
+        leaf_cert_crypto = load_der_x509_certificate(leaf_cert_bytes)
         leaf_cert = X509().from_cryptography(leaf_cert_crypto)
     except Exception as err:
         raise InvalidCertificateChain(f"Could not prepare leaf cert: {err}")
@@ -44,7 +43,7 @@ def validate_certificate_chain(
         # May be an empty array, that's fine
         intermediate_certs_bytes = x5c[1:]
         intermediate_certs_crypto = [
-            load_der_x509_certificate(cert, default_backend()) for cert in intermediate_certs_bytes
+            load_der_x509_certificate(cert) for cert in intermediate_certs_bytes
         ]
         intermediate_certs = [X509().from_cryptography(cert) for cert in intermediate_certs_crypto]
     except Exception as err:

--- a/webauthn/registration/formats/android_key.py
+++ b/webauthn/registration/formats/android_key.py
@@ -4,7 +4,6 @@ from typing import List
 from asn1crypto.core import OctetString
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.x509 import (
     Extension,
@@ -70,7 +69,7 @@ def verify_android_key(
     x5c_no_root = attestation_statement.x5c[:-1]
     x5c_root_cert = attestation_statement.x5c[-1]
 
-    x5c_root_cert_x509 = x509.load_der_x509_certificate(x5c_root_cert, default_backend())
+    x5c_root_cert_x509 = x509.load_der_x509_certificate(x5c_root_cert)
     x5c_root_cert_pem = x5c_root_cert_x509.public_bytes(Encoding.PEM)
 
     # Make sure x509 forms a complete, valid cert chain
@@ -113,7 +112,7 @@ def verify_android_key(
     # and clientDataHash using the public key in the first certificate in x5c with the
     # algorithm specified in alg.
     attestation_cert_bytes = attestation_statement.x5c[0]
-    attestation_cert = x509.load_der_x509_certificate(attestation_cert_bytes, default_backend())
+    attestation_cert = x509.load_der_x509_certificate(attestation_cert_bytes)
     attestation_cert_pub_key = attestation_cert.public_key()
 
     try:

--- a/webauthn/registration/formats/android_safetynet.py
+++ b/webauthn/registration/formats/android_safetynet.py
@@ -6,7 +6,6 @@ from typing import List
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import NameOID
 
 from webauthn.helpers.cose import COSEAlgorithmIdentifier
@@ -149,7 +148,7 @@ def verify_android_safetynet(
             raise InvalidRegistrationResponse(f"{err} (SafetyNet)")
 
     # Verify that the leaf certificate was issued to the hostname attest.android.com
-    attestation_cert = x509.load_der_x509_certificate(x5c[0], default_backend())
+    attestation_cert = x509.load_der_x509_certificate(x5c[0])
     cert_common_name = attestation_cert.subject.get_attributes_for_oid(
         NameOID.COMMON_NAME,
     )[0]

--- a/webauthn/registration/formats/apple.py
+++ b/webauthn/registration/formats/apple.py
@@ -1,9 +1,7 @@
 import hashlib
 from typing import List
 
-import cbor2
 from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.x509 import (
     Extension,
@@ -76,7 +74,7 @@ def verify_apple(
     # Verify that nonce equals the value of the extension with
     # OID 1.2.840.113635.100.8.2 in credCert.
     attestation_cert_bytes = attestation_statement.x5c[0]
-    attestation_cert = x509.load_der_x509_certificate(attestation_cert_bytes, default_backend())
+    attestation_cert = x509.load_der_x509_certificate(attestation_cert_bytes)
     cert_extensions = attestation_cert.extensions
 
     # Still no documented name for this OID...

--- a/webauthn/registration/formats/fido_u2f.py
+++ b/webauthn/registration/formats/fido_u2f.py
@@ -3,7 +3,6 @@ from typing import List
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.ec import (
     SECP256R1,
     EllipticCurvePublicKey,
@@ -73,7 +72,7 @@ def verify_fido_u2f(
 
     # Get the public key from the leaf certificate
     leaf_cert_bytes = attestation_statement.x5c[0]
-    leaf_cert = x509.load_der_x509_certificate(leaf_cert_bytes, default_backend())
+    leaf_cert = x509.load_der_x509_certificate(leaf_cert_bytes)
     leaf_cert_pub_key = leaf_cert.public_key()
 
     # We need the cert's x and y points so make sure they exist

--- a/webauthn/registration/formats/packed.py
+++ b/webauthn/registration/formats/packed.py
@@ -3,7 +3,6 @@ from typing import List
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 
 from webauthn.helpers import (
     decode_credential_public_key,
@@ -64,9 +63,7 @@ def verify_packed(
             raise InvalidRegistrationResponse(f"{err} (Packed)")
 
         attestation_cert_bytes = attestation_statement.x5c[0]
-        attestation_cert = x509.load_der_x509_certificate(
-            attestation_cert_bytes, default_backend()
-        )
+        attestation_cert = x509.load_der_x509_certificate(attestation_cert_bytes)
         attestation_cert_pub_key = attestation_cert.public_key()
 
         try:

--- a/webauthn/registration/formats/tpm.py
+++ b/webauthn/registration/formats/tpm.py
@@ -2,7 +2,6 @@ from typing import List
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import (
     ExtendedKeyUsage,
     GeneralName,
@@ -189,7 +188,7 @@ def verify_tpm(
     # Verify the sig is a valid signature over certInfo using the attestation
     # public key in aikCert with the algorithm specified in alg.
     attestation_cert_bytes = attestation_statement.x5c[0]
-    attestation_cert = x509.load_der_x509_certificate(attestation_cert_bytes, default_backend())
+    attestation_cert = x509.load_der_x509_certificate(attestation_cert_bytes)
     attestation_cert_pub_key = attestation_cert.public_key()
 
     try:


### PR DESCRIPTION
I stumbled on to the fact that the `backend` arg has been silently ignored since **cryptography 3.1**:

https://cryptography.io/en/latest/faq/#what-happened-to-the-backend-argument

> `cryptography` stopped requiring the use of `backend` arguments in version 3.1 and deprecated their use in version 36.0. If you are on an older version that requires these arguments please view the appropriate documentation version or upgrade to the latest release.
>
> Note that for forward compatibility `backend` is still silently accepted by functions that previously required it, but it is ignored and no longer documented.

I decided to remove all use of `default_backend()` that was being passed in for the `backend` arg to take advantage of this fact. I think it makes for more readable code.