### PR TITLE
Add new `options_to_json_dict` helper

### DIFF
--- a/tests/test_options_to_json_dict.py
+++ b/tests/test_options_to_json_dict.py
@@ -1,0 +1,93 @@
+from unittest import TestCase
+
+from webauthn.helpers.cose import COSEAlgorithmIdentifier
+from webauthn.helpers.options_to_json_dict import options_to_json_dict
+from webauthn.helpers.structs import (
+    AttestationConveyancePreference,
+    AuthenticatorAttachment,
+    AuthenticatorSelectionCriteria,
+    PublicKeyCredentialDescriptor,
+    PublicKeyCredentialHint,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+from webauthn import generate_registration_options, generate_authentication_options
+
+
+class TestWebAuthnOptionsToJSON(TestCase):
+    maxDiff = None
+
+    def test_converts_registration_options_to_JSON(self) -> None:
+        options = generate_registration_options(
+            rp_id="example.com",
+            rp_name="Example Co",
+            user_id=bytes([1, 2, 3, 4]),
+            user_name="lee",
+            user_display_name="Lee",
+            attestation=AttestationConveyancePreference.DIRECT,
+            authenticator_selection=AuthenticatorSelectionCriteria(
+                authenticator_attachment=AuthenticatorAttachment.PLATFORM,
+                resident_key=ResidentKeyRequirement.REQUIRED,
+            ),
+            challenge=b"1234567890",
+            exclude_credentials=[
+                PublicKeyCredentialDescriptor(id=b"1234567890"),
+            ],
+            supported_pub_key_algs=[COSEAlgorithmIdentifier.ECDSA_SHA_512],
+            timeout=120000,
+            hints=[
+                PublicKeyCredentialHint.SECURITY_KEY,
+                PublicKeyCredentialHint.CLIENT_DEVICE,
+                PublicKeyCredentialHint.HYBRID,
+            ],
+        )
+
+        output = options_to_json_dict(options)
+
+        self.assertEqual(
+            output,
+            {
+                "rp": {"name": "Example Co", "id": "example.com"},
+                "user": {
+                    "id": "AQIDBA",
+                    "name": "lee",
+                    "displayName": "Lee",
+                },
+                "challenge": "MTIzNDU2Nzg5MA",
+                "pubKeyCredParams": [{"type": "public-key", "alg": -36}],
+                "timeout": 120000,
+                "excludeCredentials": [{"type": "public-key", "id": "MTIzNDU2Nzg5MA"}],
+                "authenticatorSelection": {
+                    "authenticatorAttachment": "platform",
+                    "residentKey": "required",
+                    "requireResidentKey": True,
+                    "userVerification": "preferred",
+                },
+                "attestation": "direct",
+                "hints": ["security-key", "client-device", "hybrid"],
+            },
+        )
+
+    def test_converts_authentication_options_to_JSON(self) -> None:
+        options = generate_authentication_options(
+            rp_id="example.com",
+            challenge=b"1234567890",
+            allow_credentials=[
+                PublicKeyCredentialDescriptor(id=b"1234567890"),
+            ],
+            timeout=120000,
+            user_verification=UserVerificationRequirement.DISCOURAGED,
+        )
+
+        output = options_to_json_dict(options)
+
+        self.assertEqual(
+            output,
+            {
+                "rpId": "example.com",
+                "challenge": "MTIzNDU2Nzg5MA",
+                "allowCredentials": [{"type": "public-key", "id": "MTIzNDU2Nzg5MA"}],
+                "timeout": 120000,
+                "userVerification": "discouraged",
+            },
+        )

--- a/webauthn/helpers/__init__.py
+++ b/webauthn/helpers/__init__.py
@@ -9,6 +9,7 @@ from .generate_challenge import generate_challenge
 from .generate_user_handle import generate_user_handle
 from .hash_by_alg import hash_by_alg
 from .options_to_json import options_to_json
+from .options_to_json_dict import options_to_json_dict
 from .parse_attestation_object import parse_attestation_object
 from .parse_authentication_credential_json import parse_authentication_credential_json
 from .parse_authentication_options_json import parse_authentication_options_json
@@ -34,6 +35,7 @@ __all__ = [
     "generate_user_handle",
     "hash_by_alg",
     "options_to_json",
+    "options_to_json_dict",
     "parse_attestation_object",
     "parse_authenticator_data",
     "parse_authentication_credential_json",

--- a/webauthn/helpers/options_to_json.py
+++ b/webauthn/helpers/options_to_json.py
@@ -1,127 +1,23 @@
 import json
-from typing import Union, Dict, Any
+from typing import Union
 
 from .structs import (
     PublicKeyCredentialCreationOptions,
     PublicKeyCredentialRequestOptions,
 )
-from .bytes_to_base64url import bytes_to_base64url
+from .options_to_json_dict import options_to_json_dict
 
 
 def options_to_json(
     options: Union[
         PublicKeyCredentialCreationOptions,
         PublicKeyCredentialRequestOptions,
-    ]
+    ],
 ) -> str:
     """
-    Prepare options for transmission to the front end as JSON
+    Convert registration or authentication options into a simple JSON dictionary, and then stringify
+    the result to send to the front end as `Content-Type: application/json`. Alternatively use
+    `webauthn.helpers.options_to_json_dict` to get a raw `dict` instead to combine the options with
+    other data beforehand/encode with a different scheme/etc...
     """
-    if isinstance(options, PublicKeyCredentialCreationOptions):
-        _rp = {"name": options.rp.name}
-        if options.rp.id:
-            _rp["id"] = options.rp.id
-
-        _user: Dict[str, Any] = {
-            "id": bytes_to_base64url(options.user.id),
-            "name": options.user.name,
-            "displayName": options.user.display_name,
-        }
-
-        reg_to_return: Dict[str, Any] = {
-            "rp": _rp,
-            "user": _user,
-            "challenge": bytes_to_base64url(options.challenge),
-            "pubKeyCredParams": [
-                {"type": param.type, "alg": param.alg} for param in options.pub_key_cred_params
-            ],
-        }
-
-        # Begin handling optional values
-
-        if options.timeout is not None:
-            reg_to_return["timeout"] = options.timeout
-
-        if options.exclude_credentials is not None:
-            _excluded = options.exclude_credentials
-            json_excluded = []
-
-            for cred in _excluded:
-                json_excluded_cred: Dict[str, Any] = {
-                    "id": bytes_to_base64url(cred.id),
-                    "type": cred.type.value,
-                }
-
-                if cred.transports:
-                    json_excluded_cred["transports"] = [
-                        transport.value for transport in cred.transports
-                    ]
-
-                json_excluded.append(json_excluded_cred)
-
-            reg_to_return["excludeCredentials"] = json_excluded
-
-        if options.authenticator_selection is not None:
-            _selection = options.authenticator_selection
-            json_selection: Dict[str, Any] = {}
-
-            if _selection.authenticator_attachment is not None:
-                json_selection["authenticatorAttachment"] = (
-                    _selection.authenticator_attachment.value
-                )
-
-            if _selection.resident_key is not None:
-                json_selection["residentKey"] = _selection.resident_key.value
-
-            if _selection.require_resident_key is not None:
-                json_selection["requireResidentKey"] = _selection.require_resident_key
-
-            if _selection.user_verification is not None:
-                json_selection["userVerification"] = _selection.user_verification.value
-
-            reg_to_return["authenticatorSelection"] = json_selection
-
-        if options.attestation is not None:
-            reg_to_return["attestation"] = options.attestation.value
-
-        if options.hints is not None:
-            reg_to_return["hints"] = [hint.value for hint in options.hints]
-
-        return json.dumps(reg_to_return)
-
-    if isinstance(options, PublicKeyCredentialRequestOptions):
-        auth_to_return: Dict[str, Any] = {"challenge": bytes_to_base64url(options.challenge)}
-
-        if options.timeout is not None:
-            auth_to_return["timeout"] = options.timeout
-
-        if options.rp_id is not None:
-            auth_to_return["rpId"] = options.rp_id
-
-        if options.allow_credentials is not None:
-            _allowed = options.allow_credentials
-            json_allowed = []
-
-            for cred in _allowed:
-                json_allowed_cred: Dict[str, Any] = {
-                    "id": bytes_to_base64url(cred.id),
-                    "type": cred.type.value,
-                }
-
-                if cred.transports:
-                    json_allowed_cred["transports"] = [
-                        transport.value for transport in cred.transports
-                    ]
-
-                json_allowed.append(json_allowed_cred)
-
-            auth_to_return["allowCredentials"] = json_allowed
-
-        if options.user_verification:
-            auth_to_return["userVerification"] = options.user_verification.value
-
-        return json.dumps(auth_to_return)
-
-    raise TypeError(
-        "Options was not instance of PublicKeyCredentialCreationOptions or PublicKeyCredentialRequestOptions"
-    )
+    return json.dumps(options_to_json_dict(options=options))

--- a/webauthn/helpers/options_to_json_dict.py
+++ b/webauthn/helpers/options_to_json_dict.py
@@ -14,9 +14,9 @@ def options_to_json_dict(
     ],
 ) -> Dict[str, Any]:
     """
-    Convert registration or authentication options into a simple JSON dictionary. Alternatively use
-    `webauthn.helpers.options_to_json` to perform this conversion _and_ stringify the resulting
-    `dict` before sending it to the front end.
+    Convert registration or authentication options into a simple JSON dictionary. Alternatively, use
+    `webauthn.helpers.options_to_json` to perform this conversion and then stringify the resulting
+    `dict` to make it easier to send to the front end.
     """
     if isinstance(options, PublicKeyCredentialCreationOptions):
         _rp = {"name": options.rp.name}

--- a/webauthn/helpers/options_to_json_dict.py
+++ b/webauthn/helpers/options_to_json_dict.py
@@ -1,0 +1,128 @@
+from typing import Union, Dict, Any
+
+from .structs import (
+    PublicKeyCredentialCreationOptions,
+    PublicKeyCredentialRequestOptions,
+)
+from .bytes_to_base64url import bytes_to_base64url
+
+
+def options_to_json_dict(
+    options: Union[
+        PublicKeyCredentialCreationOptions,
+        PublicKeyCredentialRequestOptions,
+    ],
+) -> Dict[str, Any]:
+    """
+    Convert registration or authentication options into a simple JSON dictionary. Alternatively use
+    `webauthn.helpers.options_to_json` to perform this conversion _and_ stringify the resulting
+    `dict` before sending it to the front end.
+    """
+    if isinstance(options, PublicKeyCredentialCreationOptions):
+        _rp = {"name": options.rp.name}
+        if options.rp.id:
+            _rp["id"] = options.rp.id
+
+        _user: Dict[str, Any] = {
+            "id": bytes_to_base64url(options.user.id),
+            "name": options.user.name,
+            "displayName": options.user.display_name,
+        }
+
+        reg_to_return: Dict[str, Any] = {
+            "rp": _rp,
+            "user": _user,
+            "challenge": bytes_to_base64url(options.challenge),
+            "pubKeyCredParams": [
+                {"type": param.type, "alg": param.alg} for param in options.pub_key_cred_params
+            ],
+        }
+
+        # Begin handling optional values
+
+        if options.timeout is not None:
+            reg_to_return["timeout"] = options.timeout
+
+        if options.exclude_credentials is not None:
+            _excluded = options.exclude_credentials
+            json_excluded = []
+
+            for cred in _excluded:
+                json_excluded_cred: Dict[str, Any] = {
+                    "id": bytes_to_base64url(cred.id),
+                    "type": cred.type.value,
+                }
+
+                if cred.transports:
+                    json_excluded_cred["transports"] = [
+                        transport.value for transport in cred.transports
+                    ]
+
+                json_excluded.append(json_excluded_cred)
+
+            reg_to_return["excludeCredentials"] = json_excluded
+
+        if options.authenticator_selection is not None:
+            _selection = options.authenticator_selection
+            json_selection: Dict[str, Any] = {}
+
+            if _selection.authenticator_attachment is not None:
+                json_selection["authenticatorAttachment"] = (
+                    _selection.authenticator_attachment.value
+                )
+
+            if _selection.resident_key is not None:
+                json_selection["residentKey"] = _selection.resident_key.value
+
+            if _selection.require_resident_key is not None:
+                json_selection["requireResidentKey"] = _selection.require_resident_key
+
+            if _selection.user_verification is not None:
+                json_selection["userVerification"] = _selection.user_verification.value
+
+            reg_to_return["authenticatorSelection"] = json_selection
+
+        if options.attestation is not None:
+            reg_to_return["attestation"] = options.attestation.value
+
+        if options.hints is not None:
+            reg_to_return["hints"] = [hint.value for hint in options.hints]
+
+        return reg_to_return
+
+    if isinstance(options, PublicKeyCredentialRequestOptions):
+        auth_to_return: Dict[str, Any] = {"challenge": bytes_to_base64url(options.challenge)}
+
+        if options.timeout is not None:
+            auth_to_return["timeout"] = options.timeout
+
+        if options.rp_id is not None:
+            auth_to_return["rpId"] = options.rp_id
+
+        if options.allow_credentials is not None:
+            _allowed = options.allow_credentials
+            json_allowed = []
+
+            for cred in _allowed:
+                json_allowed_cred: Dict[str, Any] = {
+                    "id": bytes_to_base64url(cred.id),
+                    "type": cred.type.value,
+                }
+
+                if cred.transports:
+                    json_allowed_cred["transports"] = [
+                        transport.value for transport in cred.transports
+                    ]
+
+                json_allowed.append(json_allowed_cred)
+
+            auth_to_return["allowCredentials"] = json_allowed
+
+        if options.user_verification:
+            auth_to_return["userVerification"] = options.user_verification.value
+
+        return auth_to_return
+
+    raise TypeError(
+        "Options was not instance of PublicKeyCredentialCreationOptions or PublicKeyCredentialRequestOptions"
+    )

--- a/webauthn/registration/verify_registration_response.py
+++ b/webauthn/registration/verify_registration_response.py
@@ -164,7 +164,9 @@ def verify_registration_response(
         raise InvalidRegistrationResponse("Unexpected RP ID hash")
 
     if require_user_presence and not auth_data.flags.up:
-        raise InvalidRegistrationResponse("User presence was required, but was not present during attestation")
+        raise InvalidRegistrationResponse(
+            "User presence was required, but was not present during attestation"
+        )
 
     if require_user_verification and not auth_data.flags.uv:
         raise InvalidRegistrationResponse(


### PR DESCRIPTION
This PR adds a new `options_to_json_dict` helper that performs the same operation as `options_to_json` without stringifying the `dict` at the end. This can help Relying Parties combine the simplified representation options with other data before stringifying it all before sending it to the front end.

`options_to_json` has been refactored to call `options_to_json_dict` and stringify its return value, to preserve its existing functionality.

Fixes #254.