### PR TITLE
Add new custom bytes encoder arg to `options_to_json_dict`

### DIFF
--- a/tests/test_options_to_json_dict.py
+++ b/tests/test_options_to_json_dict.py
@@ -91,3 +91,28 @@ class TestWebAuthnOptionsToJSON(TestCase):
                 "userVerification": "discouraged",
             },
         )
+
+    def test_converts_authentication_options_to_JSON_custom_bytes_encoder(self) -> None:
+        options = generate_authentication_options(
+            rp_id="example.com",
+            challenge=b"1234567890",
+            allow_credentials=[
+                PublicKeyCredentialDescriptor(id=b"1234567890"),
+            ],
+            timeout=120000,
+            user_verification=UserVerificationRequirement.DISCOURAGED,
+        )
+
+        # Return a representation with the bytes left as-is
+        output = options_to_json_dict(options, bytes_encoder=lambda x: x)
+
+        self.assertEqual(
+            output,
+            {
+                "rpId": "example.com",
+                "challenge": b"1234567890",
+                "allowCredentials": [{"type": "public-key", "id": b"1234567890"}],
+                "timeout": 120000,
+                "userVerification": "discouraged",
+            },
+        )

--- a/webauthn/helpers/options_to_json_dict.py
+++ b/webauthn/helpers/options_to_json_dict.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, Any
+from typing import Callable, Union, Dict, Any
 
 from .structs import (
     PublicKeyCredentialCreationOptions,
@@ -12,11 +12,16 @@ def options_to_json_dict(
         PublicKeyCredentialCreationOptions,
         PublicKeyCredentialRequestOptions,
     ],
+    bytes_encoder: Callable[[bytes], Any] = bytes_to_base64url,
 ) -> Dict[str, Any]:
     """
     Convert registration or authentication options into a simple JSON dictionary. Alternatively, use
     `webauthn.helpers.options_to_json` to perform this conversion and then stringify the resulting
     `dict` to make it easier to send to the front end.
+
+    Args:
+        `options`: Registration or authentication options to turn into a simple `dict`.
+        `bytes_encoder`: A custom method to encode bytes values however makes sense for the RP. Defaults to encoding bytes to Base64URL strings.
     """
     if isinstance(options, PublicKeyCredentialCreationOptions):
         _rp = {"name": options.rp.name}
@@ -24,7 +29,7 @@ def options_to_json_dict(
             _rp["id"] = options.rp.id
 
         _user: Dict[str, Any] = {
-            "id": bytes_to_base64url(options.user.id),
+            "id": bytes_encoder(options.user.id),
             "name": options.user.name,
             "displayName": options.user.display_name,
         }
@@ -32,7 +37,7 @@ def options_to_json_dict(
         reg_to_return: Dict[str, Any] = {
             "rp": _rp,
             "user": _user,
-            "challenge": bytes_to_base64url(options.challenge),
+            "challenge": bytes_encoder(options.challenge),
             "pubKeyCredParams": [
                 {"type": param.type, "alg": param.alg} for param in options.pub_key_cred_params
             ],
@@ -49,7 +54,7 @@ def options_to_json_dict(
 
             for cred in _excluded:
                 json_excluded_cred: Dict[str, Any] = {
-                    "id": bytes_to_base64url(cred.id),
+                    "id": bytes_encoder(cred.id),
                     "type": cred.type.value,
                 }
 
@@ -91,7 +96,7 @@ def options_to_json_dict(
         return reg_to_return
 
     if isinstance(options, PublicKeyCredentialRequestOptions):
-        auth_to_return: Dict[str, Any] = {"challenge": bytes_to_base64url(options.challenge)}
+        auth_to_return: Dict[str, Any] = {"challenge": bytes_encoder(options.challenge)}
 
         if options.timeout is not None:
             auth_to_return["timeout"] = options.timeout
@@ -105,7 +110,7 @@ def options_to_json_dict(
 
             for cred in _allowed:
                 json_allowed_cred: Dict[str, Any] = {
-                    "id": bytes_to_base64url(cred.id),
+                    "id": bytes_encoder(cred.id),
                     "type": cred.type.value,
                 }
 


### PR DESCRIPTION
Adding `options_to_json_dict` opens the door to offering some more control over how options get serialized to simplified, JSON-serializable `dict` representations.

Three years ago issue #135 asked for the ability to get such a representation with `bytes` values preserved as-is. In subsequent years that use case had been forgotten and I'd inadvertently broken the ability to achieve this.

This PR fixes that by adding a new `bytes_encoder` arg to `webauthn.helpers.options_to_json_dict()` that takes in `bytes` and returns whatever representation of those bytes makes sense for the RP. This arg is optional - it defaults to encoding bytes to Base64URL strings to preserve existing functionality.