### PR TITLE
Replace bare dict type hints with Dict[str, Any]

### DIFF
--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import hashlib
-from typing import List, Union
+from typing import Any, Dict, List, Union
 
 from cryptography.exceptions import InvalidSignature
 
@@ -46,7 +46,7 @@ expected_token_binding_statuses = [
 
 def verify_authentication_response(
     *,
-    credential: Union[str, dict, AuthenticationCredential],
+    credential: Union[str, Dict[str, Any], AuthenticationCredential],
     expected_challenge: bytes,
     expected_rp_id: str,
     expected_origin: Union[str, List[str]],

--- a/webauthn/helpers/parse_attestation_statement.py
+++ b/webauthn/helpers/parse_attestation_statement.py
@@ -1,7 +1,9 @@
+from typing import Any, Dict
+
 from .structs import AttestationStatement
 
 
-def parse_attestation_statement(val: dict) -> AttestationStatement:
+def parse_attestation_statement(val: Dict[str, Any]) -> AttestationStatement:
     """
     Turn `response.attestationObject.attStmt` into structured data
     """

--- a/webauthn/helpers/parse_authentication_credential_json.py
+++ b/webauthn/helpers/parse_authentication_credential_json.py
@@ -1,6 +1,6 @@
 import json
 from json.decoder import JSONDecodeError
-from typing import Union
+from typing import Any, Dict, Union
 
 from .exceptions import InvalidAuthenticationResponse, InvalidJSONStructure
 from .base64url_to_bytes import base64url_to_bytes
@@ -12,7 +12,9 @@ from .structs import (
 )
 
 
-def parse_authentication_credential_json(json_val: Union[str, dict]) -> AuthenticationCredential:
+def parse_authentication_credential_json(
+    json_val: Union[str, Dict[str, Any]]
+) -> AuthenticationCredential:
     """
     Parse a JSON form of an authentication credential, as either a stringified JSON object or a
     plain dict, into an instance of AuthenticationCredential

--- a/webauthn/helpers/parse_authentication_options_json.py
+++ b/webauthn/helpers/parse_authentication_options_json.py
@@ -1,6 +1,6 @@
 import json
 from json import JSONDecodeError
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from .base64url_to_bytes import base64url_to_bytes
 from .exceptions import InvalidJSONStructure, InvalidAuthenticationOptions
@@ -13,7 +13,7 @@ from .structs import (
 
 
 def parse_authentication_options_json(
-    json_val: Union[str, dict]
+    json_val: Union[str, Dict[str, Any]]
 ) -> PublicKeyCredentialRequestOptions:
     """
     Parse a JSON form of authentication options, as either stringified JSON or a plain dict, into an

--- a/webauthn/helpers/parse_registration_credential_json.py
+++ b/webauthn/helpers/parse_registration_credential_json.py
@@ -1,6 +1,6 @@
 import json
 from json.decoder import JSONDecodeError
-from typing import Union, Optional, List
+from typing import Any, Dict, Union, Optional, List
 
 from .base64url_to_bytes import base64url_to_bytes
 from .exceptions import InvalidRegistrationResponse, InvalidJSONStructure
@@ -13,7 +13,9 @@ from .structs import (
 )
 
 
-def parse_registration_credential_json(json_val: Union[str, dict]) -> RegistrationCredential:
+def parse_registration_credential_json(
+    json_val: Union[str, Dict[str, Any]]
+) -> RegistrationCredential:
     """
     Parse a JSON form of a registration credential, as either a stringified JSON object or a
     plain dict, into an instance of RegistrationCredential

--- a/webauthn/helpers/parse_registration_options_json.py
+++ b/webauthn/helpers/parse_registration_options_json.py
@@ -1,6 +1,6 @@
 import json
 from json.decoder import JSONDecodeError
-from typing import Union, Optional, List
+from typing import Any, Dict, Union, Optional, List
 
 
 from .structs import (
@@ -23,7 +23,7 @@ from .base64url_to_bytes import base64url_to_bytes
 
 
 def parse_registration_options_json(
-    json_val: Union[str, dict]
+    json_val: Union[str, Dict[str, Any]]
 ) -> PublicKeyCredentialCreationOptions:
     """
     Parse a JSON form of registration options, as either stringified JSON or a plain dict, into an

--- a/webauthn/registration/verify_registration_response.py
+++ b/webauthn/registration/verify_registration_response.py
@@ -1,6 +1,6 @@
 import hashlib
 from dataclasses import dataclass, asdict
-from typing import List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from webauthn.helpers import (
     aaguid_to_string,
@@ -66,7 +66,7 @@ expected_token_binding_statuses = [
 
 def verify_registration_response(
     *,
-    credential: Union[str, dict, RegistrationCredential],
+    credential: Union[str, Dict[str, Any], RegistrationCredential],
     expected_challenge: bytes,
     expected_rp_id: str,
     expected_origin: Union[str, List[str]],


### PR DESCRIPTION
Added proper dict type hints to prevent type checker complaints in strict mode.

current error example:
```
Type of "parse_registration_options_json" is partially unknown
  Type of "parse_registration_options_json" is "(json_val: str | dict[Unknown, Unknown]) -> PublicKeyCredentialCreationOptions"
```
