### PR TITLE
Bump cbor2 version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module is available on **PyPI**:
 
 ## Requirements
 
-- Python 3.9 and up
+- Python 3.10 and up
 
 ## Usage
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 
 [mypy-cbor2.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "pyasn1>=0.6.2",
     "cbor2>=5.9.0,<6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "pyasn1>=0.6.2",
-    "cbor2>=5.9.0,<6.0.0",
+    "cbor2>=6.0.1",
     "cryptography>=44.0.2",
     "pyOpenSSL>=25.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "pyasn1>=0.6.2",
-    "cbor2>=5.6.5",
+    "cbor2>=5.9.0,<6.0.0",
     "cryptography>=44.0.2",
     "pyOpenSSL>=25.0.0",
 ]

--- a/webauthn/helpers/parse_cbor.py
+++ b/webauthn/helpers/parse_cbor.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import cbor2
 
+from .byteslike_to_bytes import byteslike_to_bytes
 from .exceptions import InvalidCBORData
 
 
@@ -13,6 +14,7 @@ def parse_cbor(data: bytes) -> Any:
         `helpers.exceptions.InvalidCBORData` if data cannot be decoded
     """
     try:
+        data = byteslike_to_bytes(data)
         to_return = cbor2.loads(data)
     except Exception as exc:
         raise InvalidCBORData("Could not decode CBOR data") from exc


### PR DESCRIPTION
Hi! This PR bumps cbor2 version to address the following CVE: https://github.com/advisories/GHSA-3c37-wwvx-h642

This is related to issue #267.

I upgraded to cbor2 v6 and fixed the failing test caused by breaking changes introduced in the new version.
also bumping to v6 requires raising the minimum supported Python version to 3.10. Since Python 3.9 is already EOL, I don’t think this should be a major issue.

If maintaining Python 3.9 support is preferred, an alternative fix would be applying this patch instead: https://github.com/typestring/py_webauthn/commit/8385a6a1c3f79f2c0a883d3c20aef092ebd5aa55