### PR TITLE
Improve attestationObject and clientDataJSON parsing during registration

### DIFF
--- a/tests/test_verify_registration_response.py
+++ b/tests/test_verify_registration_response.py
@@ -10,7 +10,11 @@ from webauthn.helpers import (
     parse_cbor,
     parse_attestation_object,
 )
-from webauthn.helpers.exceptions import InvalidRegistrationResponse, InvalidCBORData
+from webauthn.helpers.exceptions import (
+    InvalidAttestationObjectStructure,
+    InvalidRegistrationResponse,
+    InvalidJSONStructure,
+)
 from webauthn.helpers.known_root_certs import globalsign_r2
 from webauthn.helpers.structs import (
     AttestationFormat,
@@ -247,8 +251,7 @@ class TestVerifyRegistrationResponse(TestCase):
         assert verification.fmt == AttestationFormat.NONE
 
     def test_supports_already_parsed_credential(self) -> None:
-        parsed_credential = parse_registration_credential_json(
-            """{
+        parsed_credential = parse_registration_credential_json("""{
                 "id": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
                 "rawId": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
                 "response": {
@@ -260,8 +263,7 @@ class TestVerifyRegistrationResponse(TestCase):
                 "transports": [
                     "cable"
                 ]
-            }"""
-        )
+            }""")
 
         challenge = base64url_to_bytes(
             "TwN7n4WTyGKLc4ZY-qGsFqKnHM4nglqsyV0ICJlN2TO9XiRyFtrkaDwUvsql-gkLJXP6fnF1MlrZ53Mm4R7Cvw"
@@ -325,10 +327,64 @@ class TestVerifyRegistrationResponse(TestCase):
         rp_id = "localhost"
         expected_origin = "http://localhost:5000"
 
-        with self.assertRaises(InvalidCBORData):
+        bad_values = [
+            "",
+            "AA",  # cbor2.dumps(0)
+            "AQ",  # cbor2.dumps(1)
+            "GRPn",  # cbor2.dumps(999)
+            "GYmP",  # cbor2.dumps(99999)
+            "YXg",  # cbor2.dumps("x")
+            "gwECAw",  # cbor2.dumps([1,2,3])
+            "9g",  # cbor2.dumps(None)
+        ]
+
+        for value in bad_values:
+            with self.assertRaises(InvalidRegistrationResponse) as exc:
+                _cred = dict(credential)
+                _cred["response"]["attestationObject"] = value
+
+                verify_registration_response(
+                    credential=_cred,
+                    expected_challenge=challenge,
+                    expected_origin=expected_origin,
+                    expected_rp_id=rp_id,
+                )
+
+            self.assertEqual(
+                exc.exception.__str__(),
+                "attestationObject was malformed. See __cause__ for more info",
+            )
+            self.assertIsInstance(exc.exception.__cause__, InvalidAttestationObjectStructure)
+
+    def test_raises_useful_error_on_bad_client_data_json(self) -> None:
+        credential = {
+            "id": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
+            "rawId": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
+            "response": {
+                "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjESZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NFAAAAFwAAAAAAAAAAAAAAAAAAAAAAQPctcQPE5oNRRJk_nO_371mf7qE7qIodzr0eOf6ACvnMB1oQG165dqutoi1U44shGezu5_gkTjmOPeJO0N8a7P-lAQIDJiABIVggSFbUJF-42Ug3pdM8rDRFu_N5oiVEysPDB6n66r_7dZAiWCDUVnB39FlGypL-qAoIO9xWHtJygo2jfDmHl-_eKFRLDA",
+                "clientDataJSON": "",  # <--- Empty
+            },
+            "type": "public-key",
+            "clientExtensionResults": {},
+            "transports": ["cable"],
+        }
+
+        challenge = base64url_to_bytes(
+            "TwN7n4WTyGKLc4ZY-qGsFqKnHM4nglqsyV0ICJlN2TO9XiRyFtrkaDwUvsql-gkLJXP6fnF1MlrZ53Mm4R7Cvw"
+        )
+        rp_id = "localhost"
+        expected_origin = "http://localhost:5000"
+
+        with self.assertRaises(InvalidRegistrationResponse) as exc:
             verify_registration_response(
                 credential=credential,
                 expected_challenge=challenge,
                 expected_origin=expected_origin,
                 expected_rp_id=rp_id,
             )
+
+        self.assertEqual(
+            exc.exception.__str__(),
+            "clientDataJSON was malformed. See __cause__ for more info",
+        )
+        self.assertIsInstance(exc.exception.__cause__, InvalidJSONStructure)

--- a/webauthn/helpers/exceptions.py
+++ b/webauthn/helpers/exceptions.py
@@ -68,3 +68,7 @@ class InvalidBackupFlags(WebAuthnException):
 
 class InvalidCBORData(WebAuthnException):
     pass
+
+
+class InvalidAttestationObjectStructure(WebAuthnException):
+    pass

--- a/webauthn/helpers/parse_attestation_object.py
+++ b/webauthn/helpers/parse_attestation_object.py
@@ -2,6 +2,7 @@ from .parse_attestation_statement import parse_attestation_statement
 from .parse_authenticator_data import parse_authenticator_data
 from .structs import AttestationObject
 from .parse_cbor import parse_cbor
+from .exceptions import InvalidAttestationObjectStructure, InvalidCBORData
 
 
 def parse_attestation_object(val: bytes) -> AttestationObject:
@@ -9,7 +10,23 @@ def parse_attestation_object(val: bytes) -> AttestationObject:
     Decode and peel apart the CBOR-encoded blob `response.attestationObject` into
     structured data.
     """
-    attestation_dict = parse_cbor(val)
+    try:
+        attestation_dict = parse_cbor(val)
+    except InvalidCBORData:
+        raise InvalidAttestationObjectStructure("Could not parse attestationObject as CBOR data")
+
+    if type(attestation_dict) is not dict:
+        raise InvalidAttestationObjectStructure("attestationObject was not a dict")
+
+    if "fmt" not in attestation_dict:
+        raise InvalidAttestationObjectStructure(
+            'attestationObject missing required property "fmt"'
+        )
+
+    if "authData" not in attestation_dict:
+        raise InvalidAttestationObjectStructure(
+            'attestationObject missing required property "authData"'
+        )
 
     decoded_attestation_object = AttestationObject(
         fmt=attestation_dict["fmt"],

--- a/webauthn/helpers/parse_client_data_json.py
+++ b/webauthn/helpers/parse_client_data_json.py
@@ -17,15 +17,15 @@ def parse_client_data_json(val: bytes) -> CollectedClientData:
     try:
         json_dict = json.loads(val)
     except JSONDecodeError:
-        raise InvalidJSONStructure("Unable to decode client_data_json bytes as JSON")
+        raise InvalidJSONStructure("Unable to decode clientDataJSON bytes as JSON")
 
     # Ensure required values are present in client data
     if "type" not in json_dict:
-        raise InvalidJSONStructure('client_data_json missing required property "type"')
+        raise InvalidJSONStructure('clientDataJSON missing required property "type"')
     if "challenge" not in json_dict:
-        raise InvalidJSONStructure('client_data_json missing required property "challenge"')
+        raise InvalidJSONStructure('clientDataJSON missing required property "challenge"')
     if "origin" not in json_dict:
-        raise InvalidJSONStructure('client_data_json missing required property "origin"')
+        raise InvalidJSONStructure('clientDataJSON missing required property "origin"')
 
     client_data = CollectedClientData(
         type=json_dict["type"],

--- a/webauthn/helpers/parse_client_data_json.py
+++ b/webauthn/helpers/parse_client_data_json.py
@@ -19,6 +19,9 @@ def parse_client_data_json(val: bytes) -> CollectedClientData:
     except JSONDecodeError:
         raise InvalidJSONStructure("Unable to decode clientDataJSON bytes as JSON")
 
+    if type(json_dict) is not dict:
+        raise InvalidJSONStructure("clientDataJSON was not a dict")
+
     # Ensure required values are present in client data
     if "type" not in json_dict:
         raise InvalidJSONStructure('clientDataJSON missing required property "type"')

--- a/webauthn/helpers/parse_registration_credential_json.py
+++ b/webauthn/helpers/parse_registration_credential_json.py
@@ -14,7 +14,7 @@ from .structs import (
 
 
 def parse_registration_credential_json(
-    json_val: Union[str, Dict[str, Any]]
+    json_val: Union[str, Dict[str, Any]],
 ) -> RegistrationCredential:
     """
     Parse a JSON form of a registration credential, as either a stringified JSON object or a

--- a/webauthn/registration/verify_registration_response.py
+++ b/webauthn/registration/verify_registration_response.py
@@ -121,7 +121,12 @@ def verify_registration_response(
     client_data_bytes = byteslike_to_bytes(response.client_data_json)
     attestation_object_bytes = byteslike_to_bytes(response.attestation_object)
 
-    client_data = parse_client_data_json(client_data_bytes)
+    try:
+        client_data = parse_client_data_json(client_data_bytes)
+    except Exception as exc:
+        raise InvalidRegistrationResponse(
+            "clientDataJSON was malformed. See __cause__ for more info"
+        ) from exc
 
     if client_data.type != ClientDataType.WEBAUTHN_CREATE:
         raise InvalidRegistrationResponse(
@@ -151,7 +156,12 @@ def verify_registration_response(
                 f'Unexpected token_binding status of "{status}", expected one of "{",".join(expected_token_binding_statuses)}"'
             )
 
-    attestation_object = parse_attestation_object(attestation_object_bytes)
+    try:
+        attestation_object = parse_attestation_object(attestation_object_bytes)
+    except Exception as exc:
+        raise InvalidRegistrationResponse(
+            "attestationObject was malformed. See __cause__ for more info"
+        ) from exc
 
     auth_data = attestation_object.auth_data
 


### PR DESCRIPTION
This PR updates `parse_attestation_object()` and `parse_client_data_json()` to more robustly handle malformed values.

The improvements primarily involve updating `verify_registration_response()` to return `InvalidRegistrationResponse` when trying to parse bad `attestationObject` or `clientDataJSON` values, with the `__cause__` set to a new `InvalidAttestationObjectStructure` exception or the existing `InvalidJSONStructure` exception respectively.

Fixes #270 

## attestationObject parsing exceptions

Using the bad, base64url-encoded value of `cbor2.dumps(99999)`:

### Before

```
[bad attestationObject: "GYmP"]
exc: TypeError("'int' object is not subscriptable")
exc.__cause__: None
```

### After

```
[bad attestationObject: "GYmP"]
exc: InvalidRegistrationResponse('attestationObject was malformed. See __cause__ for more info')
exc.__cause__: InvalidAttestationObjectStructure('attestationObject was not a dict')
```

## clientDataJSON parsing exceptions

### Before

```
[bad clientDataJSON: ""]
exc: InvalidJSONStructure('Unable to decode client_data_json bytes as JSON')
exc.__cause__: None
```

### After

```
[bad clientDataJSON: ""]
exc: InvalidRegistrationResponse('clientDataJSON was malformed. See __cause__ for more info')
exc.__cause__: InvalidJSONStructure('Unable to decode clientDataJSON bytes as JSON')
```