### PR TITLE
Restrict cbor2 support to <6 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "pyasn1>=0.6.2",
-    "cbor2>=6.0.1",
+    "cbor2>=5.6.5,<6",
     "cryptography>=44.0.2",
     "pyOpenSSL>=25.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "pyasn1>=0.6.2",
-    "cbor2>=5.6.5,<6",
+    "cbor2>=5.6.5,<6.0.0",
     "cryptography>=44.0.2",
     "pyOpenSSL>=25.0.0",
 ]


### PR DESCRIPTION
The `cbor2` v6+ update seen a relatively large number of updates since its debut at the end of March 2026:

<img width="1318" height="1065" alt="Screenshot 2026-06-09 at 11 00 37 AM" src="https://github.com/user-attachments/assets/c6427bcf-acae-4a76-bb04-4841309f65cf" />

I'm going to restrict py_webauthn to `cbor>=5.6.5,<6.0.0` for now and give that project a couple more months to settle into their recent Rust rewrite.

Relates to #267 