### PR TITLE
Normalize TPM manufacturer IDs before attempting to look them up

### DIFF
--- a/tests/test_map_tpm_manufacturer_id.py
+++ b/tests/test_map_tpm_manufacturer_id.py
@@ -13,3 +13,16 @@ class TestWebAuthnGenerateUserHandle(TestCase):
     def test_raises_on_unrecognized_id(self) -> None:
         with self.assertRaises(KeyError):
             map_tpm_manufacturer_id("id:FFFFFFFF")
+
+    def test_normalizes_id_before_lookup_qualcomm(self) -> None:
+        # A real TPM manufacturer ID observed in the wild. The final "d" should be a "D"
+        info = map_tpm_manufacturer_id("id:51434f4d")
+
+        self.assertEqual(info.name, "Qualcomm")
+        self.assertEqual(info.id, "QCOM")
+
+    def test_normalizes_id_before_lookup_ibm(self) -> None:
+        info = map_tpm_manufacturer_id("id:49424d00")
+
+        self.assertEqual(info.name, "IBM")
+        self.assertEqual(info.id, "IBM")

--- a/webauthn/helpers/tpm/map_tpm_manufacturer.py
+++ b/webauthn/helpers/tpm/map_tpm_manufacturer.py
@@ -3,7 +3,8 @@ from .structs import TPM_MANUFACTURERS, TPMManufacturerInfo
 
 def map_tpm_manufacturer_id(id: str) -> TPMManufacturerInfo:
     """
-    Map a TPM manufacturer's hex ID to a manufacturer's assigned name and ASCII identifier
+    Map a TPM manufacturer's hex ID to a manufacturer's assigned name and ASCII identifier. IDs
+    will be normalized to all-uppercase before attempting to look up a manufacturer.
 
     Args:
         - `id`: A TPM manufacturer ID string like `"id:FFFFFFFF"`
@@ -15,4 +16,6 @@ def map_tpm_manufacturer_id(id: str) -> TPMManufacturerInfo:
     Raises:
         `KeyError` on unrecognized TPM manufacturer ID
     """
-    return TPM_MANUFACTURERS[id]
+    # e.g. "id:51434f4d" -> "id:51434f4D"
+    normalized_id = f"id:{id[3:].upper()}"
+    return TPM_MANUFACTURERS[normalized_id]

--- a/webauthn/helpers/tpm/structs.py
+++ b/webauthn/helpers/tpm/structs.py
@@ -394,7 +394,8 @@ TPM_MANUFACTURERS: Mapping[str, TPMManufacturerInfo] = {
     "id:48504900": TPMManufacturerInfo(name="HPI", id="HPI"),
     "id:48504500": TPMManufacturerInfo(name="HPE", id="HPE"),
     "id:48495349": TPMManufacturerInfo(name="Huawei", id="HISI"),
-    "id:49424d00": TPMManufacturerInfo(name="IBM", id="IBM"),
+    # IBM ID is "id:49424d00" in the TCG registry; normalizing it to "id:49424D00" for easier lookup
+    "id:49424D00": TPMManufacturerInfo(name="IBM", id="IBM"),
     "id:49465800": TPMManufacturerInfo(name="Infineon", id="IFX"),
     "id:494E5443": TPMManufacturerInfo(name="Intel", id="INTC"),
     "id:4C454E00": TPMManufacturerInfo(name="Lenovo", id="LEN"),


### PR DESCRIPTION
This PR updates TPM attestation verification to normalize TPM manufacturer IDs before trying to find an entry for them. This should resolve issues with recent Qualcomm TPMs returning `"id:51434f4d"` as their manufacturer ID in `"tpm"` attestations.

Fixes #274 