### PR TITLE
Update errors to highlight availability of `__cause__`

### DIFF
--- a/webauthn/helpers/encode_cbor.py
+++ b/webauthn/helpers/encode_cbor.py
@@ -15,6 +15,8 @@ def encode_cbor(val: Any) -> bytes:
     try:
         to_return = cbor2.dumps(val)
     except Exception as exc:
-        raise InvalidCBORData("Data could not be encoded to CBOR") from exc
+        raise InvalidCBORData(
+            "Data could not be encoded to CBOR. See __cause__ for more info"
+        ) from exc
 
     return to_return

--- a/webauthn/helpers/parse_authentication_credential_json.py
+++ b/webauthn/helpers/parse_authentication_credential_json.py
@@ -13,7 +13,7 @@ from .structs import (
 
 
 def parse_authentication_credential_json(
-    json_val: Union[str, Dict[str, Any]]
+    json_val: Union[str, Dict[str, Any]],
 ) -> AuthenticationCredential:
     """
     Parse a JSON form of an authentication credential, as either a stringified JSON object or a
@@ -96,7 +96,7 @@ def parse_authentication_credential_json(
         )
     except Exception as exc:
         raise InvalidAuthenticationResponse(
-            "Could not parse authentication credential from JSON data"
+            "Could not parse authentication credential from JSON data. See __cause__ for more info"
         ) from exc
 
     return authentication_credential

--- a/webauthn/helpers/parse_authentication_options_json.py
+++ b/webauthn/helpers/parse_authentication_options_json.py
@@ -13,7 +13,7 @@ from .structs import (
 
 
 def parse_authentication_options_json(
-    json_val: Union[str, Dict[str, Any]]
+    json_val: Union[str, Dict[str, Any]],
 ) -> PublicKeyCredentialRequestOptions:
     """
     Parse a JSON form of authentication options, as either stringified JSON or a plain dict, into an
@@ -63,7 +63,9 @@ def parse_authentication_options_json(
     try:
         mapped_user_verification = UserVerificationRequirement(options_user_verification)
     except ValueError as exc:
-        raise InvalidJSONStructure("Options userVerification was invalid value") from exc
+        raise InvalidJSONStructure(
+            "Options userVerification was invalid value. See __cause__ for more info"
+        ) from exc
 
     """
     Check allowCredentials
@@ -91,7 +93,7 @@ def parse_authentication_options_json(
                     ]
                 except ValueError as exc:
                     raise InvalidJSONStructure(
-                        "Options excludeCredentials entry transports had invalid value"
+                        "Options excludeCredentials entry transports had invalid value. See __cause__ for more info"
                     ) from exc
 
             mapped_allow_credentials.append(_mapped)
@@ -106,7 +108,7 @@ def parse_authentication_options_json(
         )
     except Exception as exc:
         raise InvalidAuthenticationOptions(
-            "Could not parse authentication options from JSON data"
+            "Could not parse authentication options from JSON data. See __cause__ for more info"
         ) from exc
 
     return authentication_options

--- a/webauthn/helpers/parse_cbor.py
+++ b/webauthn/helpers/parse_cbor.py
@@ -17,6 +17,6 @@ def parse_cbor(data: bytes) -> Any:
         data = byteslike_to_bytes(data)
         to_return = cbor2.loads(data)
     except Exception as exc:
-        raise InvalidCBORData("Could not decode CBOR data") from exc
+        raise InvalidCBORData("Could not decode CBOR data. See __cause__ for more info") from exc
 
     return to_return

--- a/webauthn/helpers/parse_registration_credential_json.py
+++ b/webauthn/helpers/parse_registration_credential_json.py
@@ -93,7 +93,7 @@ def parse_registration_credential_json(
         )
     except Exception as exc:
         raise InvalidRegistrationResponse(
-            "Could not parse registration credential from JSON data"
+            "Could not parse registration credential from JSON data. See __cause__ for more info"
         ) from exc
 
     return registration_credential

--- a/webauthn/helpers/parse_registration_options_json.py
+++ b/webauthn/helpers/parse_registration_options_json.py
@@ -23,7 +23,7 @@ from .base64url_to_bytes import base64url_to_bytes
 
 
 def parse_registration_options_json(
-    json_val: Union[str, Dict[str, Any]]
+    json_val: Union[str, Dict[str, Any]],
 ) -> PublicKeyCredentialCreationOptions:
     """
     Parse a JSON form of registration options, as either stringified JSON or a plain dict, into an
@@ -84,7 +84,9 @@ def parse_registration_options_json(
     try:
         mapped_attestation = AttestationConveyancePreference(options_attestation)
     except ValueError as exc:
-        raise InvalidJSONStructure("Options attestation was invalid value") from exc
+        raise InvalidJSONStructure(
+            "Options attestation was invalid value. See __cause__ for more info"
+        ) from exc
 
     """
     Check authenticatorSelection
@@ -99,7 +101,7 @@ def parse_registration_options_json(
                 mapped_attachment = AuthenticatorAttachment(options_authr_selection_attachment)
             except ValueError as exc:
                 raise InvalidJSONStructure(
-                    "Options authenticatorSelection attachment was invalid value"
+                    "Options authenticatorSelection attachment was invalid value. See __cause__ for more info"
                 ) from exc
 
         options_authr_selection_rkey = options_authr_selection.get("residentKey")
@@ -109,7 +111,7 @@ def parse_registration_options_json(
                 mapped_rkey = ResidentKeyRequirement(options_authr_selection_rkey)
             except ValueError as exc:
                 raise InvalidJSONStructure(
-                    "Options authenticatorSelection residentKey was invalid value"
+                    "Options authenticatorSelection residentKey was invalid value. See __cause__ for more info"
                 ) from exc
 
         options_authr_selection_require_rkey = options_authr_selection.get("requireResidentKey")
@@ -129,7 +131,7 @@ def parse_registration_options_json(
                 mapped_user_verification = UserVerificationRequirement(options_authr_selection_uv)
             except ValueError as exc:
                 raise InvalidJSONStructure(
-                    "Options authenticatorSelection userVerification was invalid value"
+                    "Options authenticatorSelection userVerification was invalid value. See __cause__ for more info"
                 ) from exc
 
         mapped_authenticator_selection = AuthenticatorSelectionCriteria(
@@ -161,7 +163,9 @@ def parse_registration_options_json(
             for param in options_pub_key_cred_params
         ]
     except ValueError as exc:
-        raise InvalidJSONStructure("Options pubKeyCredParams entry had invalid alg") from exc
+        raise InvalidJSONStructure(
+            "Options pubKeyCredParams entry had invalid alg. See __cause__ for more info"
+        ) from exc
 
     """
     Check excludeCredentials
@@ -189,7 +193,7 @@ def parse_registration_options_json(
                     ]
                 except ValueError as exc:
                     raise InvalidJSONStructure(
-                        "Options excludeCredentials entry transports had invalid value"
+                        "Options excludeCredentials entry transports had invalid value. See __cause__ for more info"
                     ) from exc
 
             mapped_exclude_credentials.append(_mapped)
@@ -214,7 +218,9 @@ def parse_registration_options_json(
         try:
             mapped_hints = [PublicKeyCredentialHint(hint) for hint in options_hints]
         except ValueError as exc:
-            raise InvalidJSONStructure("Options hints had invalid value") from exc
+            raise InvalidJSONStructure(
+                "Options hints had invalid value. See __cause__ for more info"
+            ) from exc
 
     try:
         registration_options = PublicKeyCredentialCreationOptions(
@@ -237,7 +243,7 @@ def parse_registration_options_json(
         )
     except Exception as exc:
         raise InvalidRegistrationOptions(
-            "Could not parse registration options from JSON data"
+            "Could not parse registration options from JSON data. See __cause__ for more info"
         ) from exc
 
     return registration_options

--- a/webauthn/helpers/validate_certificate_chain.py
+++ b/webauthn/helpers/validate_certificate_chain.py
@@ -36,7 +36,9 @@ def validate_certificate_chain(
         leaf_cert_crypto = load_der_x509_certificate(leaf_cert_bytes)
         leaf_cert = X509().from_cryptography(leaf_cert_crypto)
     except Exception as exc:
-        raise InvalidCertificateChain("Could not prepare leaf cert") from exc
+        raise InvalidCertificateChain(
+            "Could not prepare leaf cert. See __cause__ for more info"
+        ) from exc
 
     # Prepare any intermediate certs
     try:
@@ -47,7 +49,9 @@ def validate_certificate_chain(
         ]
         intermediate_certs = [X509().from_cryptography(cert) for cert in intermediate_certs_crypto]
     except Exception as exc:
-        raise InvalidCertificateChain("Could not prepare intermediate certs") from exc
+        raise InvalidCertificateChain(
+            "Could not prepare intermediate certs. See __cause__ for more info"
+        ) from exc
 
     # Prepare a collection of possible root certificates
     cert_store = _generate_new_cert_store()
@@ -55,7 +59,9 @@ def validate_certificate_chain(
         for cert in pem_root_certs_bytes:
             cert_store.add_cert(pem_cert_bytes_to_open_ssl_x509(cert))
     except Exception as exc:
-        raise InvalidCertificateChain("Could not prepare root certs") from exc
+        raise InvalidCertificateChain(
+            "Could not prepare root certs. See __cause__ for more info"
+        ) from exc
 
     # Load certs into a "context" for validation
     context = X509StoreContext(
@@ -68,7 +74,9 @@ def validate_certificate_chain(
     try:
         context.verify_certificate()
     except X509StoreContextError as exc:
-        raise InvalidCertificateChain("Certificate chain could not be validated") from exc
+        raise InvalidCertificateChain(
+            "Certificate chain could not be validated. See __cause__ for more info"
+        ) from exc
 
     return True
 


### PR DESCRIPTION
This PR normalizes the pattern of including "See __cause__ for more info" in an exception's error message when the exception is raised with `from exc`. `__cause__` will include the original exception including a stacktrace of the reason the custom exception was raised.