### PR TITLE
Add more parsing exception handling during auth

### DIFF
--- a/tests/test_verify_authentication_response.py
+++ b/tests/test_verify_authentication_response.py
@@ -2,7 +2,11 @@ from unittest import TestCase
 
 from webauthn import verify_authentication_response
 from webauthn.helpers import base64url_to_bytes, parse_authentication_credential_json
-from webauthn.helpers.exceptions import InvalidAuthenticationResponse
+from webauthn.helpers.exceptions import (
+    InvalidAuthenticationResponse,
+    InvalidAuthenticatorDataStructure,
+    InvalidJSONStructure,
+)
 
 
 class TestVerifyAuthenticationResponse(TestCase):
@@ -224,8 +228,7 @@ class TestVerifyAuthenticationResponse(TestCase):
         )
 
     def test_supports_already_parsed_credential(self) -> None:
-        parsed_credential = parse_authentication_credential_json(
-            """{
+        parsed_credential = parse_authentication_credential_json("""{
             "id": "ZoIKP1JQvKdrYj1bTUPJ2eTUsbLeFkv-X5xJQNr4k6s",
             "rawId": "ZoIKP1JQvKdrYj1bTUPJ2eTUsbLeFkv-X5xJQNr4k6s",
             "response": {
@@ -236,8 +239,7 @@ class TestVerifyAuthenticationResponse(TestCase):
             },
             "type": "public-key",
             "clientExtensionResults": {}
-        }"""
-        )
+        }""")
         challenge = base64url_to_bytes(
             "iPmAi1Pp1XL6oAgq3PWZtZPnZa1zFUDoGbaQ0_KvVG1lF2s3Rt_3o4uSzccy0tmcTIpTTT4BU1T-I4maavndjQ"
         )
@@ -294,3 +296,65 @@ class TestVerifyAuthenticationResponse(TestCase):
         )
 
         assert verification.new_sign_count == 1
+
+    def test_raises_on_bad_authenticator_data(self):
+        with self.assertRaisesRegex(
+            InvalidAuthenticationResponse,
+            "authenticatorData was malformed. See __cause__ for more info",
+        ) as raised:
+            # authenticatorData below is intentionally truncated to be bad data
+            verify_authentication_response(
+                credential="""{
+                "id": "EDx9FfAbp4obx6oll2oC4-CZuDidRVV4gZhxC529ytlnqHyqCStDUwfNdm1SNHAe3X5KvueWQdAX3x9R1a2b9Q",
+                "rawId": "EDx9FfAbp4obx6oll2oC4-CZuDidRVV4gZhxC529ytlnqHyqCStDUwfNdm1SNHAe3X5KvueWQdAX3x9R1a2b9Q",
+                "response": {
+                    "authenticatorData": "SZYN5YgOjGh0NBcPZHZg",
+                    "clientDataJSON": "eyJjaGFsbGVuZ2UiOiJ4aTMwR1BHQUZZUnhWRHBZMXNNMTBEYUx6VlFHNjZudi1fN1JVYXpIMHZJMll2RzhMWWdERW52TjVmWlpOVnV2RUR1TWk5dGUzVkxxYjQyTjBma0xHQSIsImNsaWVudEV4dGVuc2lvbnMiOnt9LCJoYXNoQWxnb3JpdGhtIjoiU0hBLTI1NiIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTAwMCIsInR5cGUiOiJ3ZWJhdXRobi5nZXQifQ",
+                    "signature": "MEUCIGisVZOBapCWbnJJvjelIzwpixxIwkjCCb5aCHafQu68AiEA88v-2pJNNApPFwAKFiNuf82-2hBxYW5kGwVweeoxCwo"
+                },
+                "type": "public-key",
+                "clientExtensionResults": {}
+            }""",
+                expected_challenge=base64url_to_bytes(
+                    "xi30GPGAFYRxVDpY1sM10DaLzVQG66nv-_7RUazH0vI2YvG8LYgDEnvN5fZZNVuvEDuMi9te3VLqb42N0fkLGA"
+                ),
+                expected_rp_id="localhost",
+                expected_origin="http://localhost:5000",
+                credential_public_key=base64url_to_bytes(
+                    "pQECAyYgASFYIIeDTe-gN8A-zQclHoRnGFWN8ehM1b7yAsa8I8KIvmplIlgg4nFGT5px8o6gpPZZhO01wdy9crDSA_Ngtkx0vGpvPHI"
+                ),
+                credential_current_sign_count=77,
+            )
+
+        self.assertIsInstance(raised.exception.__cause__, InvalidAuthenticatorDataStructure)
+
+    def test_raises_on_bad_client_data_json(self):
+        with self.assertRaisesRegex(
+            InvalidAuthenticationResponse,
+            "clientDataJSON was malformed. See __cause__ for more info",
+        ) as raised:
+            # clientDataJSON below is intentionally truncated to be bad data
+            verify_authentication_response(
+                credential="""{
+                "id": "EDx9FfAbp4obx6oll2oC4-CZuDidRVV4gZhxC529ytlnqHyqCStDUwfNdm1SNHAe3X5KvueWQdAX3x9R1a2b9Q",
+                "rawId": "EDx9FfAbp4obx6oll2oC4-CZuDidRVV4gZhxC529ytlnqHyqCStDUwfNdm1SNHAe3X5KvueWQdAX3x9R1a2b9Q",
+                "response": {
+                    "authenticatorData": "SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MBAAAATg",
+                    "clientDataJSON": "eyJjaGFsbGVuZ2UiOiJ4aTMwR1BH",
+                    "signature": "MEUCIGisVZOBapCWbnJJvjelIzwpixxIwkjCCb5aCHafQu68AiEA88v-2pJNNApPFwAKFiNuf82-2hBxYW5kGwVweeoxCwo"
+                },
+                "type": "public-key",
+                "clientExtensionResults": {}
+            }""",
+                expected_challenge=base64url_to_bytes(
+                    "xi30GPGAFYRxVDpY1sM10DaLzVQG66nv-_7RUazH0vI2YvG8LYgDEnvN5fZZNVuvEDuMi9te3VLqb42N0fkLGA"
+                ),
+                expected_rp_id="localhost",
+                expected_origin="http://localhost:5000",
+                credential_public_key=base64url_to_bytes(
+                    "pQECAyYgASFYIIeDTe-gN8A-zQclHoRnGFWN8ehM1b7yAsa8I8KIvmplIlgg4nFGT5px8o6gpPZZhO01wdy9crDSA_Ngtkx0vGpvPHI"
+                ),
+                credential_current_sign_count=77,
+            )
+
+        self.assertIsInstance(raised.exception.__cause__, InvalidJSONStructure)

--- a/tests/test_verify_registration_response.py
+++ b/tests/test_verify_registration_response.py
@@ -388,3 +388,63 @@ class TestVerifyRegistrationResponse(TestCase):
             "clientDataJSON was malformed. See __cause__ for more info",
         )
         self.assertIsInstance(exc.exception.__cause__, InvalidJSONStructure)
+
+    def test_raises_on_bad_attestationObject(self) -> None:
+        with self.assertRaisesRegex(
+            InvalidRegistrationResponse,
+            "attestationObject was malformed. See __cause__ for more info",
+        ) as raised:
+            # attestationObject below is intentionally truncated to be bad data
+            verify_registration_response(
+                credential="""{
+                "id": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
+                "rawId": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
+                "response": {
+                    "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjESZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NFAAAAFwAAAAAAAAAAAAAAAAAAAAAAQPctcQPE5oNRRJk_nO_371mf7qE7qIodzr0eOf6ACvnMB1oQG165dqutoi1U44shGezu5_gkTjmOPeJO0N8a7P",
+                    "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiVHdON240V1R5R0tMYzRaWS1xR3NGcUtuSE00bmdscXN5VjBJQ0psTjJUTzlYaVJ5RnRya2FEd1V2c3FsLWdrTEpYUDZmbkYxTWxyWjUzTW00UjdDdnciLCJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjUwMDAiLCJjcm9zc09yaWdpbiI6ZmFsc2V9"
+                },
+                "type": "public-key",
+                "clientExtensionResults": {},
+                "transports": [
+                    "nfc",
+                    "usb"
+                ]
+            }""",
+                expected_challenge=base64url_to_bytes(
+                    "TwN7n4WTyGKLc4ZY-qGsFqKnHM4nglqsyV0ICJlN2TO9XiRyFtrkaDwUvsql-gkLJXP6fnF1MlrZ53Mm4R7Cvw"
+                ),
+                expected_origin="http://localhost:5000",
+                expected_rp_id="localhost",
+            )
+
+        self.assertIsInstance(raised.exception.__cause__, InvalidAttestationObjectStructure)
+
+    def test_raises_on_bad_client_data_json(self) -> None:
+        with self.assertRaisesRegex(
+            InvalidRegistrationResponse,
+            "clientDataJSON was malformed. See __cause__ for more info",
+        ) as raised:
+            # clientDataJSON below is intentionally truncated to be bad data
+            verify_registration_response(
+                credential="""{
+                "id": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
+                "rawId": "9y1xA8Tmg1FEmT-c7_fvWZ_uoTuoih3OvR45_oAK-cwHWhAbXrl2q62iLVTjiyEZ7O7n-CROOY494k7Q3xrs_w",
+                "response": {
+                    "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjESZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NFAAAAFwAAAAAAAAAAAAAAAAAAAAAAQPctcQPE5oNRRJk_nO_371mf7qE7qIodzr0eOf6ACvnMB1oQG165dqutoi1U44shGezu5_gkTjmOPeJO0N8a7P-lAQIDJiABIVggSFbUJF-42Ug3pdM8rDRFu_N5oiVEysPDB6n66r_7dZAiWCDUVnB39FlGypL-qAoIO9xWHtJygo2jfDmHl-_eKFRLDA",
+                    "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRl"
+                },
+                "type": "public-key",
+                "clientExtensionResults": {},
+                "transports": [
+                    "nfc",
+                    "usb"
+                ]
+            }""",
+                expected_challenge=base64url_to_bytes(
+                    "TwN7n4WTyGKLc4ZY-qGsFqKnHM4nglqsyV0ICJlN2TO9XiRyFtrkaDwUvsql-gkLJXP6fnF1MlrZ53Mm4R7Cvw"
+                ),
+                expected_origin="http://localhost:5000",
+                expected_rp_id="localhost",
+            )
+
+        self.assertIsInstance(raised.exception.__cause__, InvalidJSONStructure)

--- a/webauthn/authentication/verify_authentication_response.py
+++ b/webauthn/authentication/verify_authentication_response.py
@@ -97,7 +97,12 @@ def verify_authentication_response(
     authenticator_data_bytes = byteslike_to_bytes(response.authenticator_data)
     signature_bytes = byteslike_to_bytes(response.signature)
 
-    client_data = parse_client_data_json(client_data_bytes)
+    try:
+        client_data = parse_client_data_json(client_data_bytes)
+    except Exception as exc:
+        raise InvalidAuthenticationResponse(
+            "clientDataJSON was malformed. See __cause__ for more info"
+        ) from exc
 
     if client_data.type != ClientDataType.WEBAUTHN_GET:
         raise InvalidAuthenticationResponse(
@@ -127,7 +132,12 @@ def verify_authentication_response(
                 f'Unexpected token_binding status of "{status}", expected one of "{",".join(expected_token_binding_statuses)}"'
             )
 
-    auth_data = parse_authenticator_data(authenticator_data_bytes)
+    try:
+        auth_data = parse_authenticator_data(authenticator_data_bytes)
+    except Exception as exc:
+        raise InvalidAuthenticationResponse(
+            "authenticatorData was malformed. See __cause__ for more info"
+        ) from exc
 
     # Generate a hash of the expected RP ID for comparison
     expected_rp_id_hash = hashlib.sha256()


### PR DESCRIPTION
This PR compliments work done in #271, #273, and #276 to more gracefully handle parsing errors, but this time during authentication verification. Related tests have been added for registration and authentication.