### PR TITLE
Refine default credential public key algorithms to "most popular" ones

### DIFF
--- a/tests/test_generate_registration_options.py
+++ b/tests/test_generate_registration_options.py
@@ -40,7 +40,7 @@ class TestGenerateRegistrationOptions(TestCase):
         )
         assert options.pub_key_cred_params[0] == PublicKeyCredentialParameters(
             type="public-key",
-            alg=COSEAlgorithmIdentifier.ECDSA_SHA_256,
+            alg=COSEAlgorithmIdentifier.EDDSA,
         )
         assert options.timeout == 60000
         assert options.exclude_credentials == []
@@ -134,3 +134,29 @@ class TestGenerateRegistrationOptions(TestCase):
                 rp_name="Example Co",
                 user_name="",
             )
+
+    def test_suggests_popular_default_supported_algorithms(self) -> None:
+        """
+        Popular = Ed25519 is pretty cool, so use it when it's available. ES256 and RS256 are safe
+        and common fallbacks.
+        """
+        options = generate_registration_options(
+            rp_id="example.com",
+            rp_name="Example Co",
+            user_name="blah",
+            user_id=None,
+        )
+
+        self.assertEqual(len(options.pub_key_cred_params), 3)
+        self.assertEqual(
+            options.pub_key_cred_params[0].alg,
+            COSEAlgorithmIdentifier.EDDSA,
+        )
+        self.assertEqual(
+            options.pub_key_cred_params[1].alg,
+            COSEAlgorithmIdentifier.ECDSA_SHA_256,
+        )
+        self.assertEqual(
+            options.pub_key_cred_params[2].alg,
+            COSEAlgorithmIdentifier.RSASSA_PKCS1_v1_5_SHA_256,
+        )

--- a/webauthn/registration/generate_registration_options.py
+++ b/webauthn/registration/generate_registration_options.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from webauthn.helpers import generate_challenge, generate_user_handle, byteslike_to_bytes
+from webauthn.helpers import generate_challenge, generate_user_handle
 from webauthn.helpers.cose import COSEAlgorithmIdentifier
 from webauthn.helpers.structs import (
     AttestationConveyancePreference,

--- a/webauthn/registration/generate_registration_options.py
+++ b/webauthn/registration/generate_registration_options.py
@@ -25,19 +25,11 @@ def _generate_pub_key_cred_params(
 
 
 default_supported_pub_key_algs = [
-    COSEAlgorithmIdentifier.ECDSA_SHA_256,
-    COSEAlgorithmIdentifier.EDDSA,
-    COSEAlgorithmIdentifier.ECDSA_SHA_512,
-    COSEAlgorithmIdentifier.RSASSA_PSS_SHA_256,
-    COSEAlgorithmIdentifier.RSASSA_PSS_SHA_384,
-    COSEAlgorithmIdentifier.RSASSA_PSS_SHA_512,
-    COSEAlgorithmIdentifier.RSASSA_PKCS1_v1_5_SHA_256,
-    COSEAlgorithmIdentifier.RSASSA_PKCS1_v1_5_SHA_384,
-    COSEAlgorithmIdentifier.RSASSA_PKCS1_v1_5_SHA_512,
+    COSEAlgorithmIdentifier.EDDSA,  # -8
+    COSEAlgorithmIdentifier.ECDSA_SHA_256,  # -7
+    COSEAlgorithmIdentifier.RSASSA_PKCS1_v1_5_SHA_256,  # -257
 ]
-default_supported_pub_key_params = _generate_pub_key_cred_params(
-    default_supported_pub_key_algs,
-)
+default_supported_pub_key_params = _generate_pub_key_cred_params(default_supported_pub_key_algs)
 
 
 def generate_registration_options(


### PR DESCRIPTION
This PR refines `generate_registration_options()` to encourage use of the following three credential public key algorithms, based on guidance that [I added to the WebAuthn spec](https://w3c.github.io/webauthn/#dom-publickeycredentialcreationoptions-pubkeycredparams):

1. EdDSA (`-8`)
2. ES256 (`-7`)
3. RS256 (`-257`)

This does not impact the library's ability to verify public keys using any of the algorithms in `COSEAlgorithmIdentifier`. RPs that need to support other algorithms can still define their list of algorithms as `supported_pub_key_algs` when calling `generate_registration_options()`.